### PR TITLE
Fixed bug with severity not matching spec, it's name, and added tooltips

### DIFF
--- a/src/ResultInfo.ts
+++ b/src/ResultInfo.ts
@@ -64,7 +64,7 @@ export class ResultInfo {
                 }
 
                 if (rule.configuration !== undefined && rule.configuration.defaultLevel !== undefined) {
-                    resultInfo.severityLevel = rule.configuration.defaultLevel;
+                    resultInfo.severityLevel = ResultInfo.defaultLvlToLvlConverter(rule.configuration.defaultLevel);
                 }
 
                 resultInfo.ruleDescription = Utilities.parseSarifMessage(rule.fullDescription || rule.shortDescription,
@@ -77,6 +77,8 @@ export class ResultInfo {
                 resultInfo.ruleId = ruleKey;
             }
         }
+
+        resultInfo.severityLevel = result.level || resultInfo.severityLevel || sarif.Result.level.warning;
 
         if (result.message !== undefined && result.message.text === undefined) {
             result.message.text = ruleMessageString;
@@ -109,6 +111,21 @@ export class ResultInfo {
         return Promise.resolve(locations);
     }
 
+    private static defaultLvlToLvlConverter(defaultLevel: sarif.RuleConfiguration.defaultLevel): sarif.Result.level {
+        switch (defaultLevel) {
+            case sarif.RuleConfiguration.defaultLevel.error:
+                return sarif.Result.level.error;
+            case sarif.RuleConfiguration.defaultLevel.warning:
+                return sarif.Result.level.warning;
+            case sarif.RuleConfiguration.defaultLevel.note:
+                return sarif.Result.level.note;
+            case sarif.RuleConfiguration.defaultLevel.open:
+                return sarif.Result.level.open;
+            default:
+                return sarif.Result.level.warning;
+        }
+    }
+
     public additionalProperties: { [key: string]: string };
     public assignedLocation: Location;
     public codeFlows: CodeFlow[];
@@ -120,5 +137,5 @@ export class ResultInfo {
     public ruleId = "";
     public ruleName = "";
     public ruleDescription: Message;
-    public severityLevel = sarif.RuleConfiguration.defaultLevel.warning;
+    public severityLevel: sarif.Result.level;
 }

--- a/src/SVDiagnostic.ts
+++ b/src/SVDiagnostic.ts
@@ -86,16 +86,19 @@ export class SVDiagnostic extends Diagnostic {
     }
 
     /**
-     * Translates the default level to a DiagnosticSeverity
-     * @param defaultLvl default level for the rule in the sarif file
+     * Translates the Result level to a DiagnosticSeverity
+     * @param level severity level for the result in the sarif file
      */
-    private getSeverity(defaultLvl: sarif.RuleConfiguration.defaultLevel): DiagnosticSeverity {
-        switch (defaultLvl) {
-            case sarif.RuleConfiguration.defaultLevel.warning:
-                return DiagnosticSeverity.Warning;
-            case sarif.RuleConfiguration.defaultLevel.error:
+    private getSeverity(level: sarif.Result.level): DiagnosticSeverity {
+        switch (level) {
+            case sarif.Result.level.error:
                 return DiagnosticSeverity.Error;
-            case sarif.RuleConfiguration.defaultLevel.note:
+            case sarif.Result.level.warning:
+            case sarif.Result.level.open:
+                return DiagnosticSeverity.Warning;
+            case sarif.Result.level.note:
+            case sarif.Result.level.notApplicable:
+            case sarif.Result.level.pass:
                 return DiagnosticSeverity.Information;
             default:
                 return DiagnosticSeverity.Warning;


### PR DESCRIPTION
Fixed bug with severity not matching spec, it was pulling from the rule's default level, changed it to use the results level first, then defaultlevel, and then default to warning.
Changed it's display name in the explorer from Default Level to Severity Level
Added tooltips specific to the severity level. I pulled the text from the spec and reduced it down a bit.