### PR TITLE
Adds codelens inline messages for the active result's codeflow steps

### DIFF
--- a/src/CodeFlowCodeLens.ts
+++ b/src/CodeFlowCodeLens.ts
@@ -1,0 +1,82 @@
+// /********************************************************
+// *                                                       *
+// *   Copyright (C) Microsoft. All rights reserved.       *
+// *                                                       *
+// ********************************************************/
+import * as sarif from "sarif";
+import {
+    CancellationToken, CodeLens, CodeLensProvider, Disposable, Event, EventEmitter, languages, ProviderResult,
+    TextDocument,
+} from "vscode";
+import { ExplorerContentProvider } from "./ExplorerContentProvider";
+
+/**
+ * This class handles providing the CodeFlow step codelenses for the current diagnostic
+ */
+export class CodeFlowCodeLensProvider implements CodeLensProvider {
+    private static instance: CodeFlowCodeLensProvider;
+
+    private codeLensProvider: Disposable;
+    private onDidChangeCodeLensesEmitter: EventEmitter<void> = new EventEmitter<void>();
+
+    private constructor() {
+        this.codeLensProvider = languages.registerCodeLensProvider("*", this);
+    }
+
+    static get Instance(): CodeFlowCodeLensProvider {
+        if (CodeFlowCodeLensProvider.instance === undefined) {
+            CodeFlowCodeLensProvider.instance = new CodeFlowCodeLensProvider();
+        }
+
+        return CodeFlowCodeLensProvider.instance;
+    }
+
+    /**
+     * For disposing on extension close
+     */
+    public dispose() {
+        this.codeLensProvider.dispose();
+    }
+
+    public get onDidChangeCodeLenses(): Event<void> {
+        return this.onDidChangeCodeLensesEmitter.event;
+    }
+
+    public provideCodeLenses(document: TextDocument, token: CancellationToken): ProviderResult<CodeLens[]> {
+        const codeLenses: CodeLens[] = [];
+        const explorerCP = ExplorerContentProvider.Instance;
+        const verbosity = explorerCP.codeFlowVerbosity || sarif.CodeFlowLocation.importance.important;
+
+        if (explorerCP.activeSVDiagnostic !== undefined) {
+            const codeFlows = explorerCP.activeSVDiagnostic.resultInfo.codeFlows;
+            if (codeFlows !== undefined) {
+                for (const cFIndex of codeFlows.keys()) {
+                    const codeFlow = codeFlows[cFIndex];
+                    for (const tFIndex of codeFlow.threads.keys()) {
+                        const threadFlow = codeFlow.threads[tFIndex];
+                        for (const stepIndex of threadFlow.steps.keys()) {
+                            const step = threadFlow.steps[stepIndex];
+                            if (step.location.uri.toString() === document.uri.toString()) {
+                                if (step.importance === sarif.CodeFlowLocation.importance.essential ||
+                                    verbosity === sarif.CodeFlowLocation.importance.unimportant ||
+                                    step.importance === verbosity) {
+                                    const codeLens = new CodeLens(step.location.range, step.codeLensCommand);
+                                    codeLenses.push(codeLens);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return codeLenses;
+    }
+
+    /**
+     * Use to trigger a refresh of the CodeFlow CodeLenses
+     */
+    public triggerCodeLensRefresh() {
+        this.onDidChangeCodeLensesEmitter.fire();
+    }
+}

--- a/src/Interfaces.d.ts
+++ b/src/Interfaces.d.ts
@@ -4,6 +4,7 @@
 // *                                                       *
 // ********************************************************/
 import * as sarif from "sarif";
+import { Command } from "vscode";
 import { Location } from "./Location";
 
 /**
@@ -48,19 +49,21 @@ export interface ThreadFlow {
 }
 
 export interface CodeFlowStep {
+    codeLensCommand: Command;
     importance: sarif.CodeFlowLocation.importance,
     isLastChild: boolean;
     isParent: boolean;
     location: Location;
     message: string;
+    messageWithStep: string;
     state: object;
     stepId: number;
     traversalId: string;
 }
 
 export interface Message {
+    html: HTMLLabelElement,
     text: string,
-    html: HTMLLabelElement
 }
 
 export interface Attachment {

--- a/src/Location.ts
+++ b/src/Location.ts
@@ -43,7 +43,9 @@ export class Location {
         }
 
         if (sarifLocation.region !== undefined) {
-            location.range = Location.parseRange(sarifLocation.region);
+            const parsedRange = Location.parseRange(sarifLocation.region);
+            location.range = parsedRange.range;
+            location.endOfLine = parsedRange.endOfLine;
             location.message = Utilities.parseSarifMessage(sarifLocation.region.message);
         }
 
@@ -84,11 +86,12 @@ export class Location {
      * Parses the range from the Region in the SARIF file
      * @param region region the result is located
      */
-    private static parseRange(region: sarif.Region): Range {
+    private static parseRange(region: sarif.Region): { range: Range, endOfLine: boolean } {
         let startline = 0;
         let startcol = 0;
         let endline = 0;
         let endcol = 1;
+        let eol = false;
 
         if (region.startLine !== undefined) {
             startline = region.startLine;
@@ -126,13 +129,15 @@ export class Location {
             if (endcol < startcol && endline === startline) {
                 endline++;
                 endcol = 0;
+                eol = true;
             }
         }
 
-        return new Range(startline, startcol, endline, endcol);
+        return { range: new Range(startline, startcol, endline, endcol), endOfLine: eol };
     }
 
     public id: number;
+    public endOfLine: boolean;
     public fileName: string;
     public mapped: boolean;
     public message: Message;
@@ -143,5 +148,6 @@ export class Location {
         this.range = new Range(0, 0, 0, 1);
         this.uri = null;
         this.fileName = "";
+        this.endOfLine = false;
     }
 }

--- a/src/SVCodeActionProvider.ts
+++ b/src/SVCodeActionProvider.ts
@@ -7,6 +7,8 @@ import {
     CancellationToken, CodeActionContext, CodeActionProvider, Command, commands, Disposable, languages, ProviderResult,
     Range, TextDocument,
 } from "vscode";
+import { CodeFlowCodeLensProvider } from "./CodeFlowCodeLens";
+import { CodeFlowDecorations } from "./CodeFlowDecorations";
 import { ExplorerContentProvider } from "./ExplorerContentProvider";
 import { FileMapper } from "./FileMapper";
 import { SVDiagnostic } from "./SVDiagnostic";
@@ -69,6 +71,8 @@ export class SVCodeActionProvider implements CodeActionProvider {
                 const activeSVDiagnostic = ExplorerContentProvider.Instance.activeSVDiagnostic;
                 if (activeSVDiagnostic === undefined || activeSVDiagnostic !== svDiagnostic) {
                     ExplorerContentProvider.Instance.update(svDiagnostic);
+                    CodeFlowCodeLensProvider.Instance.triggerCodeLensRefresh();
+                    CodeFlowDecorations.updateSelectionHighlight(svDiagnostic.resultInfo.assignedLocation, undefined);
                 }
 
                 const actions = this.getCodeActions(svDiagnostic);

--- a/src/explorer/explorer.js
+++ b/src/explorer/explorer.js
@@ -128,10 +128,6 @@ function onTabClicked(event) {
  */
 function onVerbosityChange(event) {
     updateTreeVerbosity();
-    sendExplorerCallback({
-        request: "verbositychanged",
-        verbositystate: document.getElementById("codeflowverbosity").value,
-    });
 }
 
 /**
@@ -219,24 +215,33 @@ function updateTreeVerbosity() {
     const value = document.getElementById("codeflowverbosity").value;
     let importantClass;
     let unimportantClass;
+    let verbosityRequest;
 
     switch (value) {
         case "0":
             importantClass = hide;
             unimportantClass = hide;
+            verbosityRequest = "essential";
             break;
         case "1":
             importantClass = show;
             unimportantClass = hide;
+            verbosityRequest = "important";
             break;
         case "2":
             importantClass = show;
             unimportantClass = show;
+            verbosityRequest = "unimportant";
             break;
     }
 
     setVerbosityShowState("important", importantClass);
     setVerbosityShowState("unimportant", unimportantClass);
+
+    sendExplorerCallback({
+        request: "verbositychanged",
+        verbosity: verbosityRequest,
+    });
 }
 
 if (document.getElementById("codeflowtab") !== null) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@
 // *                                                       *
 // ********************************************************/
 import { commands, ExtensionContext, Uri, ViewColumn } from "vscode";
+import { CodeFlowCodeLensProvider } from "./CodeFlowCodeLens";
 import { ExplorerContentProvider } from "./ExplorerContentProvider";
 import { FileMapper } from "./FileMapper";
 import { LogReader } from "./LogReader";
@@ -36,6 +37,8 @@ export function activate(context: ExtensionContext) {
     // Instantiate the CodeActionProvider which will register it's listeners
     const codeActionProvider = SVCodeActionProvider.Instance;
 
+    const codeFlowCodeLensProvider = CodeFlowCodeLensProvider.Instance;
+
     // Read the initial set of open SARIF files
     reader.readAll();
 
@@ -45,6 +48,7 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(explorerCommandDisposable);
     context.subscriptions.push(explorerRequestDisposable);
     context.subscriptions.push(codeActionProvider);
+    context.subscriptions.push(codeFlowCodeLensProvider);
     context.subscriptions.push(remapCodeActionCommandDisposable);
     context.subscriptions.push(FileMapper.Instance);
 }


### PR DESCRIPTION
Adds codelens inline messages for the active result's codeflow steps, verbosity switch controls which messages show.

Fixes some other minor bugs:
handle undefined step in the message,
handle undefined nestedlevel on call return,
selection highlight was showing on next line if region went to eol
added selection highlight when a result is clicked to highlight the result region