### PR TITLE
Fixing embedded links regex

### DIFF
--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -108,7 +108,7 @@ export class Utilities {
                 }
 
                 msgText = Utilities.unescapeBrackets(msgText);
-
+                msgHTML.text = Utilities.unescapeBrackets(msgHTML.text);
                 message = { text: msgText, html: msgHTML };
             }
         }

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -119,7 +119,7 @@ export class Utilities {
     private static fs: any;
     private static os: any;
     private static path: any;
-    private static embeddedRegEx = /[^\\](\[((?:\\\]|[^\]])+)\]\((\d+)\))/g;
+    private static embeddedRegEx = /(?:[^\\]|^)(\[((?:\\\]|[^\]])+)\]\((\d+)\))/g;
 
     /**
      * Remove the escape '\' characters from before any '[' or ']' characters in the text


### PR DESCRIPTION
* Added ^(start of the string) as optional start of the regex pattern, fixes #60
* Fixed \\[ and \\] weren't getting unescaped in the text outside the link text for the html version of the message