### PR TITLE
Updating Codeflow step key navigation hotkeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,12 +73,12 @@
         "keybindings": [
             {
                 "command": "extension.sarif.nextCodeFlowStep",
-                "key": "ctrl+f10",
+                "key": "f6",
                 "when": "!inDebugMode"
             },
             {
                 "command": "extension.sarif.previousCodeFlowStep",
-                "key": "ctrl+f9",
+                "key": "shift+f6",
                 "when": "!inDebugMode"
             },
             {

--- a/src/CodeFlowDecorations.ts
+++ b/src/CodeFlowDecorations.ts
@@ -131,8 +131,16 @@ export class CodeFlowDecorations {
                     }
                 }
             }
-            CodeFlowDecorations.updateCodeFlowSelection(nextId, undefined);
+            CodeFlowDecorations.updateCodeFlowSelection(undefined, nextId);
             ExplorerController.Instance.setSelectedCodeFlow(`${nextId.cFId}_${nextId.tFId}_${nextId.stepId}`);
+        } else {
+            const activeDiag = ExplorerController.Instance.activeSVDiagnostic;
+            if (activeDiag !== undefined && activeDiag.resultInfo !== undefined &&
+                activeDiag.resultInfo.codeFlows !== undefined && activeDiag.resultInfo.codeFlows.length > 0) {
+                const firstStepId = "0_0_0";
+                CodeFlowDecorations.updateCodeFlowSelection(firstStepId);
+                ExplorerController.Instance.setSelectedCodeFlow(firstStepId);
+            }
         }
     }
 
@@ -156,19 +164,36 @@ export class CodeFlowDecorations {
                 prevId.stepId = codeFlows[prevId.cFId].threads[prevId.tFId].steps.length - 1;
             }
 
-            CodeFlowDecorations.updateCodeFlowSelection(prevId, undefined);
+            CodeFlowDecorations.updateCodeFlowSelection(undefined, prevId);
             ExplorerController.Instance.setSelectedCodeFlow(`${prevId.cFId}_${prevId.tFId}_${prevId.stepId}`);
+        } else {
+            const activeDiag = ExplorerController.Instance.activeSVDiagnostic;
+            if (activeDiag !== undefined && activeDiag.resultInfo !== undefined) {
+                const codeflows = activeDiag.resultInfo.codeFlows;
+                if (codeflows !== undefined && codeflows.length > 0) {
+                    const cFId = activeDiag.resultInfo.codeFlows.length - 1;
+                    const tFId = activeDiag.resultInfo.codeFlows[cFId].threads.length - 1;
+                    const stepId = activeDiag.resultInfo.codeFlows[cFId].threads[tFId].steps.length - 1;
+                    const lastStepId = `${cFId}_${tFId}_${stepId}`;
+                    CodeFlowDecorations.updateCodeFlowSelection(lastStepId);
+                    ExplorerController.Instance.setSelectedCodeFlow(lastStepId);
+                }
+            }
         }
     }
 
     /**
      * Updates the decoration that represents the currently selected Code Flow in the Explorer
-     * @param id Id object of the Code Flow, set to undefined if using idText
+     * Only pass in one value and leave the other undefined, if both values are undefined the value is cleared
      * @param idText text version of the id of the Code Flow, set to undefined if using id
+     * @param idCFStep Id object of the Code Flow, set to undefined if using idText
      */
-    public static updateCodeFlowSelection(id: CodeFlowStepId, idText: string) {
+    public static updateCodeFlowSelection(idText?: string, idCFStep?: CodeFlowStepId) {
+        let id: CodeFlowStepId;
         if (idText !== undefined) {
             id = CodeFlows.parseCodeFlowId(idText);
+        } else if (idCFStep !== undefined) {
+            id = idCFStep;
         }
 
         if (id !== undefined) {
@@ -178,9 +203,9 @@ export class CodeFlowDecorations {
                 diagnostic.resultInfo.codeFlows[id.cFId].threads[id.tFId].steps[id.stepId].location,
                 diagnostic.rawResult.codeFlows[id.cFId].threadFlows[id.tFId].locations[id.stepId].location,
             );
-
-            CodeFlowDecorations.lastCodeFlowSelected = id;
         }
+
+        CodeFlowDecorations.lastCodeFlowSelected = id;
     }
 
     /**

--- a/src/ExplorerController.ts
+++ b/src/ExplorerController.ts
@@ -108,7 +108,7 @@ export class ExplorerController {
                 break;
             case MessageType.CodeFlowSelectionChange:
                 this.selectedRow = message.data;
-                CodeFlowDecorations.updateCodeFlowSelection(undefined, this.selectedRow);
+                CodeFlowDecorations.updateCodeFlowSelection(this.selectedRow);
                 break;
             case MessageType.SourceLinkClicked:
                 const locData = JSON.parse(message.data) as LocationData;

--- a/src/SVCodeActionProvider.ts
+++ b/src/SVCodeActionProvider.ts
@@ -76,6 +76,7 @@ export class SVCodeActionProvider implements CodeActionProvider {
                     CodeFlowDecorations.updateSelectionHighlight(svDiagnostic.resultInfo.assignedLocation, undefined);
                     CodeFlowDecorations.updateStepsHighlight();
                     CodeFlowDecorations.updateResultGutterIcon();
+                    CodeFlowDecorations.updateCodeFlowSelection();
                 }
 
                 const actions = this.getCodeActions(svDiagnostic);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: ExtensionContext) {
 
     context.subscriptions.push(
         commands.registerCommand(ExplorerController.SendCFSelectionToExplorerCommand, (id: string) => {
-            CodeFlowDecorations.updateCodeFlowSelection(undefined, id);
+            CodeFlowDecorations.updateCodeFlowSelection(id);
             ExplorerController.Instance.setSelectedCodeFlow(id);
         }));
 


### PR DESCRIPTION
* Updating from ctrl+f10 and ctrl+f9 to f6 and shift+f6. Fixes #55
* Added if no codeflow step has been selected f6 selects the first step in the first thread in the first codeflow and shift+f6 selects the last step in the last threadflow in the last codeflow