### PR TITLE
add progress message while loading sarif files

### DIFF
--- a/src/FileMapper.ts
+++ b/src/FileMapper.ts
@@ -7,6 +7,7 @@ import {
     ConfigurationChangeEvent, Disposable, Event, EventEmitter, InputBoxOptions, Uri, window, workspace,
 } from "vscode";
 import { sarif } from "./common/SARIFInterfaces";
+import { ProgressHelper } from "./ProgressHelper";
 import { Utilities } from "./Utilities";
 
 /**
@@ -76,7 +77,9 @@ export class FileMapper {
      * @param uriBase the base path of the uri
      */
     public async getUserToChooseFile(origUri: Uri, uriBase: string): Promise<void> {
-        return this.openFilePicker(origUri).then((path) => {
+        const oldProgressMsg = ProgressHelper.Instance.CurrentMessage;
+        await ProgressHelper.Instance.setProgressReport("Waiting for user input");
+        return this.openFilePicker(origUri).then(async (path) => {
             if (path !== undefined) {
                 const uri = Uri.parse(path);
                 let filePath: string;
@@ -112,6 +115,7 @@ export class FileMapper {
                 this.fileRemapping.set(Utilities.getFsPathWithFragment(origUri), null);
             }
 
+            await ProgressHelper.Instance.setProgressReport(oldProgressMsg);
             return Promise.resolve();
         });
     }

--- a/src/ProgressHelper.ts
+++ b/src/ProgressHelper.ts
@@ -1,0 +1,64 @@
+// /********************************************************
+// *                                                       *
+// *   Copyright (C) Microsoft. All rights reserved.       *
+// *                                                       *
+// ********************************************************/
+import { Progress } from "vscode";
+
+/**
+ * Helper for the progress message in VSCode
+ */
+export class ProgressHelper {
+    private static instance: ProgressHelper;
+
+    private progress: Progress<{ message?: string; increment?: number; }>;
+    private progressMsg: string;
+    private progressInc: number;
+
+    public static get Instance(): ProgressHelper {
+        if (ProgressHelper.instance === undefined) {
+            ProgressHelper.instance = new ProgressHelper();
+        }
+
+        return ProgressHelper.instance;
+    }
+
+    public get CurrentMessage(): string {
+        return this.progressMsg;
+    }
+
+    public get CurrentIncrement(): number {
+        return this.progressInc;
+    }
+
+    public set Progress(progress: Progress<{ message?: string; increment?: number; }>) {
+        this.progress = progress;
+        this.progressMsg = undefined;
+        this.progressInc = undefined;
+    }
+
+    /**
+     * Updates the message and increment, only sets the report if a Progress object is set
+     * @param message message to set on the progress dialog box
+     * @param increment amount to fill the progress bar
+     */
+    public async setProgressReport(message?: string, increment?: number) {
+        if (this.progress !== undefined) {
+            const update: { message?: string; increment?: number; } = {};
+            if (message !== undefined) {
+                this.progressMsg = message;
+                update.message = message;
+            }
+            if (increment !== undefined) {
+                this.progressInc = increment;
+                update.increment = increment;
+            }
+            this.progress.report(update);
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    resolve();
+                }, 100);
+            });
+        }
+    }
+}

--- a/src/RunInfoFactory.ts
+++ b/src/RunInfoFactory.ts
@@ -14,8 +14,9 @@ export class RunInfoFactory {
     /**
      * Processes the run passed in and creates a new RunInfo object with the information processed
      * @param run SARIF run object to process
+     * @param sarifFileName path and file name of the sarif file this run is in
      */
-    public static Create(run: sarif.Run): RunInfo {
+    public static Create(run: sarif.Run, sarifFileName: string): RunInfo {
         const runInfo = {} as RunInfo;
         const tool = run.tool;
         runInfo.toolName = tool.name;
@@ -30,7 +31,7 @@ export class RunInfoFactory {
         if (run.invocations !== undefined) {
             runInfo.cmdLine = run.invocations[0].commandLine;
             if (run.invocations[0].executableLocation !== undefined) {
-                runInfo.fileName = run.invocations[0].executableLocation.uri;
+                runInfo.toolFileName = run.invocations[0].executableLocation.uri;
             }
             runInfo.workingDir = run.invocations[0].workingDirectory;
         }
@@ -38,6 +39,7 @@ export class RunInfoFactory {
         runInfo.additionalProperties = run.properties;
         runInfo.uriBaseIds = run.originalUriBaseIds;
 
+        runInfo.sarifFileName = sarifFileName;
         return runInfo;
     }
 }

--- a/src/common/Interfaces.d.ts
+++ b/src/common/Interfaces.d.ts
@@ -56,7 +56,9 @@ export interface SarifViewerDiagnostic extends Diagnostic {
 export interface RunInfo {
     additionalProperties: { [key: string]: string };
     cmdLine: string;
-    fileName: string;
+    id: number;
+    sarifFileName: string;
+    toolFileName: string;
     toolFullName: string;
     toolName: string;
     uriBaseIds: { [key: string]: string };

--- a/src/explorer/webview.ts
+++ b/src/explorer/webview.ts
@@ -434,8 +434,8 @@ class ExplorerWebview {
         if (runInfo.cmdLine !== undefined) {
             tableEle.appendChild(this.createNameValueRow("Command line:", runInfo.cmdLine));
         }
-        if (runInfo.fileName !== undefined) {
-            tableEle.appendChild(this.createNameValueRow("File name:", runInfo.fileName));
+        if (runInfo.toolFileName !== undefined) {
+            tableEle.appendChild(this.createNameValueRow("File name:", runInfo.toolFileName));
         }
         if (runInfo.workingDir !== undefined) {
             tableEle.appendChild(this.createNameValueRow("Working directory:", runInfo.workingDir));


### PR DESCRIPTION
Implements: #52 
* Added progress messages while a sarif file is getting loaded. Added messages, for:
     * when mapping files
     * when requesting user input for file remapping
     * when processing the results. If over 1000 results we break it down to show 10% increase intervals, if it's less then 1000 it's not worth the over head of updating the % 10 times. (1000 is an adjustable number though so we can fine tune in later iterations as needed.)
* Added a helper to coordinate updating the progress message across classes
* Added field to RunInfo class to track which sarif file a run came from
* Changed the behavior when closing a sarif file, we now remove only the results associated with the closed file and leave the rest.(previously we cleared all results and then did a read all to reload all the results from the remaining opened sarif files)
* Update the max file to use the vscode defined value(now currently 1000)