### PR TITLE
Adds support to show the light bulb and context menu quickfix in problems panel for the sarif diagnostics that are unmapped

### DIFF
--- a/src/SVDiagnosticCollection.ts
+++ b/src/SVDiagnosticCollection.ts
@@ -105,6 +105,18 @@ export class SVDiagnosticCollection {
     }
 
     /**
+     * Gets a flat array of all the unmapped diagnostics
+     */
+    public getAllUnmappedDiagnostics(): SarifViewerDiagnostic[] {
+        const unmapped: SarifViewerDiagnostic[] = [];
+        this.unmappedIssuesCollection.forEach((value) => {
+            unmapped.push(...value);
+        });
+
+        return unmapped;
+    }
+
+    /**
      * Callback to handle whenever a mapping in the FileMapper changes
      * Goes through the diagnostics and tries to remap their locations, if not able to it gets left in the unmapped
      * Also goes through the codeflow locations, to update the locations


### PR DESCRIPTION
![quickfixinproblemswindow](https://user-images.githubusercontent.com/34690530/45781358-96ca2c80-bc14-11e8-8498-76efc34d106b.png)

To add this support I needed change from returning a command[] to a codeaction[] in the codeactionprovider. Also needed to add a way to get all of the unmapped diagnostics to tell vscode which diagnostics have the quickfix.