### PR TITLE
Stop launching Problems panel and clean up styling/Behavior of Results List

### DIFF
--- a/resources/explorer/explorer.css
+++ b/resources/explorer/explorer.css
@@ -9,10 +9,14 @@
 }
 
 body {
-    padding: 0px;
     box-shadow: #000000 0 8px 6px -6px inset;
+    display: flex;
+    flex-flow: column nowrap;
+    height: 100vh;
     overflow-x: hidden;
-    overflow-y: auto;
+    overflow-y: hidden;
+    padding: 0px;
+
 }
 
 .headercontainer {
@@ -46,9 +50,9 @@ li.expanded::before,
 }
 
 .headercontentseperator {
-    padding: 0px 10px;
-    font-size: 150%;
     color: rgba(200, 200, 200, 0.3);
+    font-size: 150%;
+    padding: 0px 9px;
 }
 
 #titleruleid,
@@ -61,22 +65,36 @@ li.expanded::before,
     color: rgb(16, 109, 192);
 }
 
+#resultdetailscontainer {
+    display: flex;
+    flex-flow: column nowrap;
+    flex: 1 1 50vh;
+}
+
+div#resultdetailscontainer:empty {
+    display: none;
+}
+
 #ruledescription {
-    padding: 10px;
-    max-height: 25vh;
+    flex: 0 0 auto;
+    max-height: 25%;
     overflow-x: hidden;
+    overflow-wrap: break-word;
+    padding: 2px 10px;
 }
 
 #tabcontainer {
     display: flex;
-    padding: 10px 0px;
+    flex: 0 0 auto;
+    overflow-x: scroll;
 }
 
 .tab {
     color: var(--vscode-tab-inactiveForeground);
     border-color: var(--color);
-    padding: 5px 10px;
+    padding: 5px 7px;
     user-select: none;
+    white-space: nowrap;
 }
 
 .tab:hover {
@@ -85,41 +103,50 @@ li.expanded::before,
 
 .tabactive>.tablabel {
     border-bottom-color: var(--vscode-tab-activeForeground);
-    border-bottom-width: 1px;
     border-bottom-style: solid;
+    border-bottom-width: 1px;
     color: var(--color);
     padding-bottom: 2px;
 }
 
 .tabcontent {
     display: none;
-    padding: 0px 10px;
     overflow-x: hidden;
+    overflow-y: scroll;
+    padding: 0px 10px;
 }
 
 .tabcontentactive {
-    display: block;
+    display: flex;
+    flex-flow: column nowrap;
 }
 
 .tabcontentheader {
-    padding-bottom: 5px;
-    border-bottom-style: solid;
-    border-bottom-color: var(--color);
-    border-bottom-width: thin;
     background-color: var(--vscode-sideBarSectionHeader-background);
+    border-bottom-color: var(--color);
+    border-bottom-style: solid;
+    border-bottom-width: thin;
     display: flex;
+    flex: 0 0 auto;
+    padding-bottom: 5px;
 }
 
 .tabcontentheaderbutton {
-    padding-left: 10px;
-    user-select: none;
     cursor: pointer;
     font-size: 150%;
+    padding-left: 10px;
+    user-select: none;
+}
+
+#tabcontentcontainer {
+    display: flex;
+    flex: 1 1 auto;
+    flex-flow: column nowrap;
 }
 
 .td-contentname {
-    white-space: nowrap;
     vertical-align: top;
+    white-space: nowrap;
 }
 
 input[type=range] {
@@ -136,21 +163,22 @@ input[type=range]:focus {
 
 input[type='range']::-webkit-slider-runnable-track {
     background: repeating-linear-gradient(90deg, transparent, transparent .30em, var(--color) .30em, transparent .45em, transparent 2em);
-    background-repeat: no-repeat;
     background-origin: content-box;
-    background-size: 100% 30%, 100% 100%, 100% 100%;
     background-position-y: 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 30%, 100% 100%, 100% 100%;
 }
 
 ul {
-    list-style-type: none;
-    padding-left: 15px;
     background: var(--background-color);
     color: var(--color);
+    list-style-type: none;
     outline: none;
+    padding-left: 15px;
 }
 
-ul.codeflowtreeroot {
+ul.codeflowtreeroot, ul.attachmentstreeroot, ul.fixestreeroot {
+    margin-bottom: 5px;
     margin-top: 5px;
     padding-left: 5px;
     padding-right: 5px;
@@ -211,4 +239,8 @@ li.codeflowselected:focus {
     padding-left: 5px;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+#codeflowtreecontainer {
+    overflow-y: scroll;
 }

--- a/resources/explorer/resultsList.css
+++ b/resources/explorer/resultsList.css
@@ -10,11 +10,13 @@
 }
 
 #resultslistcontainer {
+    display: flex;
+    flex: 1 1 50vh;
+    flex-flow: column nowrap;
     padding: 5px;
 }
 
 #resultslisttablecontainer {
-    height: 45vh;
     overflow-x: hidden;
     overflow-y: scroll;
 }
@@ -22,8 +24,8 @@
 #resultslisttable {
     border-spacing: 0px !important;
     cursor: pointer;
-    width: 100%;
     user-select: none;
+    width: 100%;
 }
 
 #resultslisttable>thead>tr>th:first-child {
@@ -128,8 +130,9 @@ button#filterinputcasebutton.active:before {
 }
 
 form#resultslistfilterinputcontainer {
-    width: 100%;
     display: flex;
+    padding-bottom: 5px;
+    width: 100%;
 }
 
 form#resultslistfilterinputcontainer.hidden {
@@ -151,12 +154,12 @@ button#filterinputcasebutton:before {
 }
 
 form input#resultslistfilterinput {
-    margin-left: 10px;
-    width: 100%;
     color: var(--vscode-input-foreground);
     border-right-style: none;
+    margin-left: 10px;
     outline-style: none;
     padding: 4px;
+    width: 100%;
 }
 
 form input#resultslistfilterinput::placeholder {
@@ -191,7 +194,6 @@ button#filterinputcasebutton:before {
     border-bottom-color: var(--color);
     border-bottom-style: solid;
     border-bottom-width: thin;
-    padding-bottom: 7px;
 }
 
 .countbadge {

--- a/src/ExplorerController.ts
+++ b/src/ExplorerController.ts
@@ -232,7 +232,7 @@ export class ExplorerController {
             <script src="${colResizeDiskPath}"></script>
         </head>
         <body>
-            <div id="resultslistheader" class="headercontainer collapsed"></div>
+            <div id="resultslistheader" class="headercontainer expanded"></div>
             <div id="resultslistcontainer">
                 <div id="resultslistbuttonbar"></div>
                 <div id="resultslisttablecontainer">

--- a/src/LogReader.ts
+++ b/src/LogReader.ts
@@ -4,9 +4,7 @@
 // *                                                       *
 // ********************************************************/
 import * as sarif from "sarif";
-import {
-    commands, Disposable, Progress, ProgressLocation, ProgressOptions, TextDocument, window, workspace,
-} from "vscode";
+import { Disposable, Progress, ProgressLocation, ProgressOptions, TextDocument, window, workspace } from "vscode";
 import { JsonMapping, ResultInfo, RunInfo } from "./common/Interfaces";
 import { FileConverter } from "./FileConverter";
 import { FileMapper } from "./FileMapper";
@@ -101,8 +99,6 @@ export class LogReader {
      * Reads through all of the text documents open in the workspace, syncs the issues with problem panel after
      */
     public async readAll(): Promise<void> {
-        commands.executeCommand("workbench.action.problems.focus");
-
         // Get all the documents and read them
         const docs = workspace.textDocuments;
 

--- a/src/explorer/resultsList.ts
+++ b/src/explorer/resultsList.ts
@@ -52,9 +52,11 @@ class ResultsList {
     public set Data(value: ResultsListData) {
         if (this.collapsedGroups[0] !== value.groupBy || this.data.resultCount !== value.resultCount) {
             this.collapsedGroups = [value.groupBy];
-            for (let index = 0; index < value.groups.length; index++) {
-                if (value.groups[index].rows.length > 25) {
-                    this.collapsedGroups.push(`${index}`);
+            if (value.groups.length > 1) {
+                for (let index = 0; index < value.groups.length; index++) {
+                    if (value.groups[index].rows.length > 25) {
+                        this.collapsedGroups.push(`${index}`);
+                    }
                 }
             }
         }

--- a/src/explorer/webview.ts
+++ b/src/explorer/webview.ts
@@ -233,7 +233,6 @@ class ExplorerWebview {
             this.addNodes(rootEle, thread.steps, 0 - thread.lvlsFirstStepIsNested);
             rootEle.addEventListener("click", this.onCodeFlowTreeClickedBind);
             container.appendChild(rootEle);
-            container.appendChild(this.createElement("br"));
         }
 
         return container;
@@ -749,7 +748,7 @@ class ExplorerWebview {
         resultDetailsContainer.appendChild(tabHeader);
 
         // Create and add the panels
-        const panelContainer = this.createElement("div", { id: "tabContentContainer" }) as HTMLDivElement;
+        const panelContainer = this.createElement("div", { id: "tabcontentcontainer" }) as HTMLDivElement;
         panelContainer.appendChild(this.createPanelResultInfo(resultInfo));
         panelContainer.appendChild(this.createPanelCodeFlow(resultInfo.codeFlows));
         panelContainer.appendChild(this.createPanelRunInfo(this.diagnostic.runInfo));


### PR DESCRIPTION
Styling tweaks to make the Results list and Sarif explorer cleaner and scale better with resizing of the window.
Remove the launching of the Problems Panel.
On Default the results list is now expanded.
If no result is selected, no details shown, the results list takes the whole height of the sarif explorer.
If only one group in the resutls list it will default to expanded no matter the count in the group.