### PR TITLE
Call stack panel

### DIFF
--- a/resources/explorer/explorer.css
+++ b/resources/explorer/explorer.css
@@ -34,7 +34,7 @@ body {
 /* expand arrow */
 .headercontainer.collapsed>label:first-child::before,
 li.collapsed::before,
-.resultslistgroup.collapsed>th::before {
+.listtablegroup.collapsed>th::before {
     content: "\25b7";
     font-weight: normal;
     padding-right: 5px;
@@ -43,7 +43,7 @@ li.collapsed::before,
 /* collapse arrow */
 .headercontainer.expanded>label:first-child::before,
 li.expanded::before,
-.resultslistgroup.expanded>th::before {
+.listtablegroup.expanded>th::before {
     content: "\25e2";
     font-weight: normal;
     padding-right: 3px;
@@ -119,6 +119,14 @@ div#resultdetailscontainer:empty {
 .tabcontentactive {
     display: flex;
     flex-flow: column nowrap;
+}
+
+#stackstabcontent.tabcontentactive {
+    display: unset;
+}
+
+#stackstabcontent {
+    padding: 0px 0px 0px 10px;
 }
 
 .tabcontentheader {

--- a/resources/explorer/listTable.css
+++ b/resources/explorer/listTable.css
@@ -1,0 +1,32 @@
+/*********************************************************** 
+// *                                                       * 
+// *   Copyright (C) Microsoft. All rights reserved.       * 
+// *                                                       * 
+// ********************************************************/
+
+.listtable {
+    border-spacing: 0px !important;
+    cursor: pointer;
+    user-select: none;
+    width: 100%;
+}
+
+.listtable>thead>tr>th:first-child {
+    width: 25px !important;
+}
+
+.listtablerow.hidden {
+    display: none;
+}
+
+tr.listtablerow:hover {
+    background-color: var(--vscode-editor-hoverHighlightBackground);
+}
+
+tr.listtablerow.selected {
+    background-color: var(--vscode-editor-inactiveSelectionBackground);
+}
+
+tr.listtablerow.selected:focus {
+    background-color: var(--vscode-editor-selectionBackground);
+}

--- a/resources/explorer/resultsList.css
+++ b/resources/explorer/resultsList.css
@@ -21,17 +21,6 @@
     overflow-y: scroll;
 }
 
-#resultslisttable {
-    border-spacing: 0px !important;
-    cursor: pointer;
-    user-select: none;
-    width: 100%;
-}
-
-#resultslisttable>thead>tr>th:first-child {
-    width: 25px !important;
-}
-
 td,
 th {
     overflow: hidden;
@@ -54,18 +43,6 @@ th>span.descending:before {
 
 tr {
     white-space: nowrap;
-}
-
-tr.resultslistrow:hover {
-    background-color: var(--vscode-editor-hoverHighlightBackground);
-}
-
-tr.resultslistrow.selected {
-    background-color: var(--vscode-editor-inactiveSelectionBackground);
-}
-
-tr.resultslistrow.selected:focus {
-    background-color: var(--vscode-editor-selectionBackground);
 }
 
 select#resultslistgroupby {
@@ -208,10 +185,6 @@ button#filterinputcasebutton:before {
     min-width: .6em;
     padding: .3em .5em;
     text-align: center;
-}
-
-.resultslistrow.hidden {
-    display: none;
 }
 
 .severityiconcell {

--- a/src/ExplorerController.ts
+++ b/src/ExplorerController.ts
@@ -207,6 +207,7 @@ export class ExplorerController {
         const scriptsPath = "out/explorer/explorer/";
 
         const cssExplorerDiskPath = this.getVSCodeResourcePath(resourcesPath, "explorer.css");
+        const cssListTableDiskPath = this.getVSCodeResourcePath(resourcesPath, "listTable.css");
         const cssResultsListDiskPath = this.getVSCodeResourcePath(resourcesPath, "resultsList.css");
         const jQueryDiskPath = this.getVSCodeResourcePath(resourcesPath, "jquery-3.3.1.min.js");
         const colResizeDiskPath = this.getVSCodeResourcePath(resourcesPath, "colResizable-1.6.min.js");
@@ -221,6 +222,7 @@ export class ExplorerController {
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>Sarif Explorer</title>
+            <link rel="stylesheet" type="text/css" href = "${cssListTableDiskPath}">
             <link rel="stylesheet" type="text/css" href = "${cssExplorerDiskPath}">
             <link rel="stylesheet" type="text/css" href = "${cssResultsListDiskPath}">
             <script src="${jQueryDiskPath}"></script>
@@ -231,7 +233,7 @@ export class ExplorerController {
             <div id="resultslistcontainer">
                 <div id="resultslistbuttonbar"></div>
                 <div id="resultslisttablecontainer">
-                    <table id="resultslisttable"></table>
+                    <table id="resultslisttable" class="listtable"></table>
                 </div>
             </div>
             <div id="resultdetailsheader" class="headercontainer expanded"></div>

--- a/src/common/Interfaces.d.ts
+++ b/src/common/Interfaces.d.ts
@@ -89,6 +89,7 @@ export interface ResultInfo {
     ruleDescription: Message;
     runId: number;
     severityLevel: sarif.Result.level;
+    stacks: Stack[];
 }
 
 export interface CodeFlow {
@@ -122,6 +123,19 @@ export interface CodeFlowStep {
     state: object;
     stepId: number;
     traversalId: string;
+}
+
+export interface Stack {
+    frames: Frame[];
+    message: Message;
+}
+
+export interface Frame {
+    location: Location;
+    message: Message;
+    name: string;
+    parameters: string[];
+    threadId: number;
 }
 
 export interface Message {

--- a/src/explorer/enums.ts
+++ b/src/explorer/enums.ts
@@ -24,6 +24,7 @@ enum tabNames {
     fixes = "fixestab",
     resultinfo = "resultinfotab",
     runinfo = "runinfotab",
+    stacks = "stackstab",
 }
 
 enum ToggleState {

--- a/src/explorer/resultsList.ts
+++ b/src/explorer/resultsList.ts
@@ -72,12 +72,12 @@ class ResultsList {
     public updateSelection() {
         const diag = this.webview.diagnostic;
         const id = JSON.stringify({ resultId: diag.resultInfo.id, runId: diag.resultInfo.runId });
-        const curSelected = document.getElementsByClassName("resultslistrow selected");
+        const curSelected = document.getElementsByClassName("listtablerow selected");
         while (curSelected.length > 0) {
             curSelected[0].classList.remove("selected");
         }
 
-        const rows = document.getElementsByClassName("resultslistrow") as HTMLCollectionOf<HTMLElement>;
+        const rows = document.getElementsByClassName("listtablerow") as HTMLCollectionOf<HTMLElement>;
         // @ts-ignore: compiler complains even though results can be iterated
         for (const row of rows) {
             if (row.dataset.id === id) {
@@ -87,7 +87,7 @@ class ResultsList {
     }
 
     /**
-     * Creates the content that shows in the results details header of the Explorer window
+     * Creates the content that shows in the results list header of the Explorer window
      */
     private createResultsListHeader() {
         const header = document.getElementById("resultslistheader") as HTMLDivElement;
@@ -281,7 +281,7 @@ class ResultsList {
         HTMLTableRowElement {
         const groupRow = this.webview.createElement("tr", {
             attributes: { "data-group": groupId, "tabindex": "0" },
-            className: `resultslistgroup ${state}`,
+            className: `listtablegroup ${state}`,
         }) as HTMLTableRowElement;
         groupRow.addEventListener("click", this.onToggleGroupBind);
 
@@ -368,7 +368,7 @@ class ResultsList {
         const frag = document.createDocumentFragment();
         const resultRowBase = this.webview.createElement("tr", {
             attributes: { "data-group": groupId, "tabindex": "0" },
-            className: `resultslistrow`,
+            className: `listtablerow`,
         }) as HTMLTableRowElement;
 
         const rowCellBase = this.webview.createElement("td") as HTMLTableDataCellElement;
@@ -477,7 +477,7 @@ class ResultsList {
      */
     private onRowClicked(event) {
         const row = event.currentTarget as HTMLTableRowElement;
-        const curSelected = row.parentElement.getElementsByClassName("resultslistrow selected");
+        const curSelected = row.parentElement.getElementsByClassName("listtablerow selected");
         while (curSelected.length > 0) {
             curSelected[0].classList.remove("selected");
         }
@@ -568,7 +568,7 @@ class ResultsList {
      * @param stateToToggle The state either expanded or collapsed to toggle all groups to
      */
     private toggleAllGroups(stateToToggle: ToggleState) {
-        const className = `resultslistgroup ${stateToToggle}`;
+        const className = `listtablegroup ${stateToToggle}`;
         const groups = document.getElementsByClassName(className) as HTMLCollectionOf<HTMLTableRowElement>;
 
         while (groups.length > 0) {
@@ -591,10 +591,11 @@ class ResultsList {
             this.collapsedGroups.splice(this.collapsedGroups.indexOf(row.dataset.group), 1);
         }
 
-        const results = document.getElementsByClassName("resultslistrow") as HTMLCollectionOf<HTMLElement>;
+        const results = document.querySelectorAll("#resultslisttable > tbody > .listtablerow") as NodeListOf<Element>;
 
         // @ts-ignore: compiler complains even though results can be iterated
         for (const result of results) {
+            // @ts-ignore: compiler complains even though result does have a dataset
             if (result.dataset.group === row.dataset.group) {
                 if (hideRow) {
                     result.classList.add("hidden");

--- a/src/explorer/webview.ts
+++ b/src/explorer/webview.ts
@@ -8,7 +8,7 @@ import * as sarif from "sarif";
 import { Position } from "vscode";
 import {
     Attachment, CodeFlow, CodeFlowStep, DiagnosticData, Fix, HTMLElementOptions, Location,
-    LocationData, Message, ResultInfo, ResultsListData, RunInfo, TreeNodeOptions, WebviewMessage,
+    LocationData, Message, ResultInfo, ResultsListData, RunInfo, Stack, TreeNodeOptions, WebviewMessage,
 } from "../common/Interfaces";
 
 /**
@@ -19,6 +19,7 @@ class ExplorerWebview {
     private hasCodeFlows: boolean;
     private hasAttachments: boolean;
     private hasFixes: boolean;
+    private hasStacks: boolean;
     private onAttachmentClickedBind;
     private onCodeFlowTreeClickedBind;
     private onCollapseAllClickedBind;
@@ -28,6 +29,7 @@ class ExplorerWebview {
     private onMessageBind;
     private onSourceLinkClickedBind;
     private onTabClickedBind;
+    private onToggleStackGroupBind;
     private onVerbosityChangeBind;
     private vscode;
     private resultsList;
@@ -41,6 +43,7 @@ class ExplorerWebview {
         this.onHeaderClickedBind = this.onHeaderClicked.bind(this);
         this.onMessageBind = this.onMessage.bind(this);
         this.onSourceLinkClickedBind = this.onSourceLinkClicked.bind(this);
+        this.onToggleStackGroupBind = this.onToggleStackGroup.bind(this);
         this.onTabClickedBind = this.onTabClicked.bind(this);
         this.onVerbosityChangeBind = this.onVerbosityChange.bind(this);
 
@@ -626,6 +629,83 @@ class ExplorerWebview {
     }
 
     /**
+     * Creates a Panel that shows the Stacks of a result
+     * @param stacks Array of Stack objects to create the panel with
+     */
+    private createPanelStacks(stacks: Stack[]): HTMLDivElement {
+        const panel = this.createPanel(tabNames.stacks);
+
+        if (stacks !== undefined) {
+            const tableEle = this.createElement("table",
+                { id: "stackstable", className: "listtable" }) as HTMLTableElement;
+
+            const headerNames = ["", "Message", "Name", "Line", "File", "Parameters", "ThreadId"];
+            const headerRow = this.createElement("tr") as HTMLTableRowElement;
+            for (const header of headerNames) {
+                const headerEle = this.createElement("th", { text: header });
+                headerRow.appendChild(headerEle);
+            }
+            const tableHeadEle = this.createElement("thead") as HTMLHeadElement;
+            tableHeadEle.appendChild(headerRow);
+            tableEle.appendChild(tableHeadEle);
+
+            const tableBodyEle = this.createElement("tbody") as HTMLBodyElement;
+            for (let stackIndex = 0; stackIndex < stacks.length; stackIndex++) {
+                const stack = stacks[stackIndex];
+                const msgRow = this.createElement("tr", {
+                    attributes: { "data-group": stackIndex, "tabindex": "0" },
+                    className: `listtablegroup ${ToggleState.expanded}`,
+                });
+                msgRow.appendChild(this.createElement("th", {
+                    attributes: { colspan: `${headerNames.length}` },
+                    text: stack.message.text,
+                }));
+                msgRow.addEventListener("click", this.onToggleStackGroupBind);
+                tableBodyEle.appendChild(msgRow);
+
+                const tdTag = "td";
+                for (const frame of stack.frames) {
+                    const fRow = this.createElement("tr", {
+                        attributes: { "data-group": stackIndex, "tabindex": "0" },
+                        className: "listtablerow",
+                    });
+                    const fLine = frame.location.range[0].line.toString();
+                    const fParameters = frame.parameters.toString();
+                    let fMsg = "";
+                    if (frame.message !== undefined) {
+                        fMsg = frame.message.text;
+                    }
+
+                    let fThreadId = "";
+                    if (frame.threadId !== undefined) {
+                        fThreadId = frame.threadId.toString();
+                    }
+
+                    fRow.appendChild(this.createElement(tdTag));
+                    fRow.appendChild(this.createElement(tdTag,
+                        { text: fMsg, tooltip: fMsg }));
+                    fRow.appendChild(this.createElement(tdTag,
+                        { text: frame.name, tooltip: frame.name }));
+                    fRow.appendChild(this.createElement(tdTag,
+                        { text: fLine, tooltip: fLine }));
+                    fRow.appendChild(this.createElement(tdTag,
+                        { text: frame.location.fileName, tooltip: frame.location.fileName }));
+                    fRow.appendChild(this.createElement(tdTag,
+                        { text: fParameters, tooltip: fParameters }));
+                    fRow.appendChild(this.createElement(tdTag,
+                        { text: fThreadId, tooltip: fThreadId }));
+                    tableBodyEle.appendChild(fRow);
+                }
+            }
+
+            tableEle.appendChild(tableBodyEle);
+            panel.appendChild(tableEle);
+        }
+
+        return panel;
+    }
+
+    /**
      * Creates the properties content to show
      * @param properties the properties object that has the bag of additional properties
      */
@@ -740,6 +820,9 @@ class ExplorerWebview {
         if (this.hasFixes) {
             container.appendChild(this.createTabElement(tabNames.fixes, "Fixes", "FIXES"));
         }
+        if (this.hasStacks) {
+            container.appendChild(this.createTabElement(tabNames.stacks, "Stacks", "STACKS"));
+        }
 
         return container;
     }
@@ -769,6 +852,7 @@ class ExplorerWebview {
         this.hasCodeFlows = resultInfo.codeFlows !== undefined;
         this.hasAttachments = resultInfo.attachments !== undefined;
         this.hasFixes = resultInfo.fixes !== undefined;
+        this.hasStacks = resultInfo.stacks !== undefined;
 
         const body = document.body;
 
@@ -787,6 +871,7 @@ class ExplorerWebview {
         panelContainer.appendChild(this.createPanelRunInfo(this.diagnostic.runInfo));
         panelContainer.appendChild(this.createPanelAttachments(resultInfo.attachments));
         panelContainer.appendChild(this.createPanelFixes(resultInfo.fixes));
+        panelContainer.appendChild(this.createPanelStacks(resultInfo.stacks));
         resultDetailsContainer.appendChild(panelContainer);
 
         // Setup any state
@@ -919,6 +1004,35 @@ class ExplorerWebview {
     }
 
     /**
+     * Toggles the group row as well as any stacks list rows that match the group
+     * @param row Group row to toggled
+     */
+    private onToggleStackGroup(event: Event) {
+        const row = event.currentTarget as HTMLTableRowElement;
+        let hideRow = false;
+        if (row.classList.contains(`${ToggleState.expanded}`)) {
+            row.classList.replace(`${ToggleState.expanded}`, `${ToggleState.collapsed}`);
+            hideRow = true;
+        } else {
+            row.classList.replace(`${ToggleState.collapsed}`, `${ToggleState.expanded}`);
+        }
+
+        const results = document.querySelectorAll("#stackstable > tbody > .listtablerow") as NodeListOf<Element>;
+
+        // @ts-ignore: compiler complains even though results can be iterated
+        for (const result of results) {
+            // @ts-ignore: compiler complains even though results have a dataset
+            if (result.dataset.group === row.dataset.group) {
+                if (hideRow) {
+                    result.classList.add("hidden");
+                } else {
+                    result.classList.remove("hidden");
+                }
+            }
+        }
+    }
+
+    /**
      * Callback when the verbosity setting is changed
      * @param event event fired when user changed the verbosity setting
      */
@@ -940,6 +1054,20 @@ class ExplorerWebview {
 
         document.getElementById(id).classList.add("tabactive");
         document.getElementById(id + "content").classList.add("tabcontentactive");
+
+        if (id === tabNames.stacks) {
+            const table = $("#stackstable");
+            if (table !== null) {
+                // @ts-ignore: colResizeable comes from the colResizable plugin, but there is no types file for it
+                table.colResizable({ disable: true });
+                // @ts-ignore: colResizeable comes from the colResizable plugin, but there is no types file for it
+                table.colResizable({
+                    disabledColumns: [0], headerOnly: true, liveDrag: true,
+                    minWidth: 26, partialRefresh: true, postbackSafe: true,
+                });
+                window.dispatchEvent(new Event("resize"));
+            }
+        }
 
         this.sendMessage({ data: id, type: MessageType.TabChanged } as WebviewMessage);
     }


### PR DESCRIPTION
Adds support for showing Stacks info in the result details section of the Sarif Explorer
Supports showing multiple stacks
Each frame shows, Message, Name, line, file, parameters, threadId
Each frame can be clicked and it will try to open that file location in the editor