### PR TITLE
Fix for exception when result contains embedded file contents with lo…

### DIFF
--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -206,12 +206,21 @@ export class Utilities {
     public static generateTempPath(filePath: string, hashValue?: string): string {
         const pathObj = Utilities.Path.parse(filePath);
         let tempPath: string = Utilities.Path.join(Utilities.SarifViewerTempDir, hashValue || "",
-            pathObj.dir.replace(pathObj.root, ""));
+            pathObj.dir.replace(pathObj.root, "").replace(":", ""));
         tempPath = tempPath.split("#").join(""); // remove the #s to not create a folder structure with fragments
         tempPath = Utilities.createDirectoryInTemp(tempPath);
-        tempPath = Utilities.Path.posix.join(tempPath, Utilities.Path.win32.basename(filePath));
+        tempPath = Utilities.Path.posix.join(tempPath, Utilities.makeFileNameSafe(Utilities.Path.win32.basename(filePath)));
 
         return tempPath;
+    }
+
+    /**
+     * This will remove illegal characters from a file name
+     * Illegal characters include \/:*?"<>|
+     * @param fileName file name to modify
+     */
+    public static makeFileNameSafe(fileName: string): string {
+        return fileName.replace(/[/\\?%*:|"<>]/g, '-');
     }
 
     /**

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -205,11 +205,11 @@ export class Utilities {
      */
     public static generateTempPath(filePath: string, hashValue?: string): string {
         const pathObj = Utilities.Path.parse(filePath);
-        let tempPath: string = Utilities.Path.join(Utilities.SarifViewerTempDir, hashValue || "",
-            pathObj.dir.replace(pathObj.root, "").replace(":", ""));
+        let basePath: string = Utilities.Path.join(Utilities.SarifViewerTempDir, hashValue || "");
+        let tempPath: string = Utilities.makeFileNameSafe(Utilities.Path.join(pathObj.dir.replace(pathObj.root, ""), Utilities.Path.win32.basename(filePath)));
         tempPath = tempPath.split("#").join(""); // remove the #s to not create a folder structure with fragments
-        tempPath = Utilities.createDirectoryInTemp(tempPath);
-        tempPath = Utilities.Path.posix.join(tempPath, Utilities.makeFileNameSafe(Utilities.Path.win32.basename(filePath)));
+        basePath = Utilities.createDirectoryInTemp(basePath);
+        tempPath = Utilities.Path.posix.join(basePath, tempPath);
 
         return tempPath;
     }


### PR DESCRIPTION
Fix for exception when result contains embedded file contents with location uri that contains illegal path characters (?:, etc).

Example: result location begins with https:// and the SARIF contains embedded file contents for this result artifact. Temporarily file to be generated from the embedded contents attempts to use partial of the location uri which contains illegal path and file name characters.  Adding sanitize method to remove such illegal characters when forming the temporary file path. 