### PR TITLE
Fix for exception when result contains embedded file contents with lo…

### DIFF
--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -205,13 +205,22 @@ export class Utilities {
      */
     public static generateTempPath(filePath: string, hashValue?: string): string {
         const pathObj = Utilities.Path.parse(filePath);
-        let tempPath: string = Utilities.Path.join(Utilities.SarifViewerTempDir, hashValue || "",
-            pathObj.dir.replace(pathObj.root, ""));
+        let basePath: string = Utilities.Path.join(Utilities.SarifViewerTempDir, hashValue || "");
+        let tempPath: string = Utilities.makeFileNameSafe(Utilities.Path.join(pathObj.dir.replace(pathObj.root, ""), Utilities.Path.win32.basename(filePath)));
         tempPath = tempPath.split("#").join(""); // remove the #s to not create a folder structure with fragments
-        tempPath = Utilities.createDirectoryInTemp(tempPath);
-        tempPath = Utilities.Path.posix.join(tempPath, Utilities.Path.win32.basename(filePath));
+        basePath = Utilities.createDirectoryInTemp(basePath);
+        tempPath = Utilities.Path.posix.join(basePath, tempPath);
 
         return tempPath;
+    }
+
+    /**
+     * This will remove illegal characters from a file name
+     * Illegal characters include \/:*?"<>|
+     * @param fileName file name to modify
+     */
+    public static makeFileNameSafe(fileName: string): string {
+        return fileName.replace(/[/\\?%*:|"<>]/g, '-');
     }
 
     /**


### PR DESCRIPTION
…… (#196)

* Fix for exception when result contains embedded file contents with location uri that contains illegal path characters (?:, etc)

* Updating to sanitize full path instead of just filename.