### PR TITLE
Fix #204: Set height for results list table

### DIFF
--- a/resources/explorer/resultsList.css
+++ b/resources/explorer/resultsList.css
@@ -17,8 +17,10 @@
 }
 
 #resultslisttablecontainer {
+    height: 50vh;
     overflow-x: hidden;
     overflow-y: scroll;
+    resize: vertical;
 }
 
 td,


### PR DESCRIPTION
This change anchors the result table container's height to the viewport height, which should fix the inability to scroll when there are too many results to fit on the screen.