### PR TITLE
Remove duplicate VSCode diagnostic concept

### DIFF
--- a/src/CodeFlowCodeLens.ts
+++ b/src/CodeFlowCodeLens.ts
@@ -4,7 +4,7 @@
 
 import { CancellationToken, CodeLens, CodeLensProvider, Disposable, Event, EventEmitter, languages, ProviderResult, TextDocument } from "vscode";
 import { ExplorerController } from "./ExplorerController";
-import { Location, SarifViewerDiagnostic } from "./common/Interfaces";
+import { Location } from "./common/Interfaces";
 import { SarifViewerVsCodeDiagnostic } from "./SarifViewerDiagnostic";
 import * as sarif from "sarif";
 
@@ -82,7 +82,7 @@ export class CodeFlowCodeLensProvider implements CodeLensProvider, Disposable {
     /**
      * Use to trigger a refresh of the CodeFlow CodeLenses
      */
-    public onDidChangeActiveDiagnostic(diagnostic: SarifViewerDiagnostic | undefined): void {
+    public onDidChangeActiveDiagnostic(diagnostic: SarifViewerVsCodeDiagnostic | undefined): void {
         this.activeDiagnostic = diagnostic;
         this.onDidChangeCodeLensesEmitter.fire();
     }

--- a/src/CodeFlowDecorations.ts
+++ b/src/CodeFlowDecorations.ts
@@ -9,7 +9,7 @@ import {
     commands, DecorationInstanceRenderOptions, DecorationOptions, DecorationRangeBehavior, DiagnosticSeverity, OverviewRulerLane,
     Position, Range, TextEditor, TextEditorDecorationType, TextEditorRevealType, Uri, ViewColumn, window, workspace, TextDocument, Disposable,
 } from "vscode";
-import { CodeFlowStep, CodeFlowStepId, Location, CodeFlow, SarifViewerDiagnostic, WebviewMessage, LocationData } from "./common/Interfaces";
+import { CodeFlowStep, CodeFlowStepId, Location, CodeFlow, WebviewMessage, LocationData } from "./common/Interfaces";
 import { ExplorerController } from "./ExplorerController";
 import { Utilities } from "./Utilities";
 import { SarifViewerVsCodeDiagnostic } from "./SarifViewerDiagnostic";
@@ -163,7 +163,7 @@ export class CodeFlowDecorations implements Disposable {
      * Selects the next CodeFlow step
      */
     private async selectNextCFStep(): Promise<void>  {
-        const diagnostic: SarifViewerDiagnostic | undefined = this.explorerController.activeDiagnostic;
+        const diagnostic: SarifViewerVsCodeDiagnostic | undefined = this.explorerController.activeDiagnostic;
         if (!diagnostic) {
             return;
         }
@@ -199,7 +199,7 @@ export class CodeFlowDecorations implements Disposable {
      * Selects the previous CodeFlow step
      */
     private async selectPrevCFStep(): Promise<void> {
-        const diagnostic: SarifViewerDiagnostic | undefined = this.explorerController.activeDiagnostic;
+        const diagnostic: SarifViewerVsCodeDiagnostic | undefined = this.explorerController.activeDiagnostic;
         if (!diagnostic) {
             return;
         }
@@ -249,7 +249,7 @@ export class CodeFlowDecorations implements Disposable {
 
         this.lastCodeFlowSelected = id;
 
-        const diagnostic: SarifViewerDiagnostic | undefined = this.explorerController.activeDiagnostic;
+        const diagnostic: SarifViewerVsCodeDiagnostic | undefined = this.explorerController.activeDiagnostic;
         if (!diagnostic) {
             return;
         }
@@ -286,7 +286,7 @@ export class CodeFlowDecorations implements Disposable {
      * @param sarifLocation raw sarif location used if location isn't mapped to get the user to try to map
      */
     private async updateSelectionHighlight(location: Location, sarifLocation?: sarif.Location): Promise<void> {
-        const diagnostic: SarifViewerDiagnostic | undefined = this.explorerController.activeDiagnostic;
+        const diagnostic: SarifViewerVsCodeDiagnostic | undefined = this.explorerController.activeDiagnostic;
 
         if (!diagnostic) {
             return;
@@ -447,7 +447,7 @@ export class CodeFlowDecorations implements Disposable {
                 if (selectionId.length > 1) {
                     await this.updateAttachmentSelection(attachmentId, parseInt(selectionId[1], 10));
                 } else {
-                    const diagnostic: SarifViewerDiagnostic | undefined = this.explorerController.activeDiagnostic;
+                    const diagnostic: SarifViewerVsCodeDiagnostic | undefined = this.explorerController.activeDiagnostic;
                     if (!diagnostic) {
                         return;
                     }

--- a/src/ExplorerController.ts
+++ b/src/ExplorerController.ts
@@ -283,22 +283,18 @@ export class ExplorerController implements Disposable {
     private sendActiveDiagnostic(focus: boolean): void {
 
         if (!this.activeDiagnostic) {
+            // Empty string is used to signal no selected diagnostic
+            this.sendMessage({data: "", type: MessageType.NewDiagnostic}, focus);
             return;
         }
 
-        let diagData: DiagnosticData = {
+        const diagData: DiagnosticData = {
             activeTab: this.activeTab,
             selectedRow: this.selectedCodeFlowRow,
             selectedVerbosity: this.selectedVerbosity,
             resultInfo: this.activeDiagnostic.resultInfo,
+            runInfo: this.activeDiagnostic.runInfo
         };
-
-        if (this.activeDiagnostic) {
-            diagData = {
-                ...diagData,
-                runInfo: this.diagnosticCollection.getRunInfo(this.activeDiagnostic.resultInfo.runId),
-            };
-        }
 
         const dataString: string = JSON.stringify(diagData);
         this.sendMessage({data: dataString, type: MessageType.NewDiagnostic}, focus);

--- a/src/LogReader.ts
+++ b/src/LogReader.ts
@@ -154,7 +154,7 @@ export class LogReader implements Disposable {
 
                         if (run.results) {
                             await ProgressHelper.Instance.setProgressReport(`Loading ${run.results.length} Results`);
-                            await this.readResults(run.results, run.tool, runInfo.id, doc.uri, runIndex);
+                            await this.readResults(runInfo, run.results, run.tool, runInfo.id, doc.uri, runIndex);
                         }
                     }
 
@@ -176,7 +176,7 @@ export class LogReader implements Disposable {
      * @param runIndex Index of the run in the sarif file
      */
     private async readResults(
-        results: sarif.Result[], tool: sarif.Tool, runId: number, docUri: Uri, runIndex: number,
+        runInfo: RunInfo, results: sarif.Result[], tool: sarif.Tool, runId: number, docUri: Uri, runIndex: number,
     ): Promise<void> {
         const showIncrement: boolean = results.length > 1000;
         let percent: number = 0;
@@ -206,7 +206,7 @@ export class LogReader implements Disposable {
                 resultInfo.assignedLocation = LocationFactory.mapToSarifFileLocation(this, docUri, runIndex, resultIndex);
             }
 
-            const diagnostic: SarifViewerVsCodeDiagnostic  = SVDiagnosticFactory.create(this.explorerController.diagnosticCollection, resultInfo, sarifResult);
+            const diagnostic: SarifViewerVsCodeDiagnostic  = SVDiagnosticFactory.create(runInfo, resultInfo, sarifResult);
             this.explorerController.diagnosticCollection.add(diagnostic);
         }
     }

--- a/src/ResultsListController.ts
+++ b/src/ResultsListController.ts
@@ -10,12 +10,13 @@ import { BaselineOrder, KindOrder, MessageType, SeverityLevelOrder } from "./com
 import {
     ResultInfo, ResultsListColumn, ResultsListCustomOrderValue, ResultsListData, ResultsListGroup,
     ResultsListPositionValue, ResultsListRow, ResultsListSortBy, ResultsListValue,
-    WebviewMessage, SarifViewerDiagnostic, Location, RunInfo
+    WebviewMessage, Location, RunInfo
 } from "./common/Interfaces";
 import { ExplorerController } from "./ExplorerController";
 import { SVCodeActionProvider } from "./SVCodeActionProvider";
 import { SVDiagnosticCollection, SVDiagnosticsChangedEvent } from "./SVDiagnosticCollection";
 import { Utilities } from "./Utilities";
+import { SarifViewerVsCodeDiagnostic } from "./SarifViewerDiagnostic";
 
 /**
  * Class that acts as the data controller for the ResultsList in the Sarif Explorer
@@ -148,7 +149,7 @@ export class ResultsListController implements Disposable {
             case MessageType.ResultsListResultSelected:
                 // What is the proper type if "id"?
                 const id: { resultId: number; runId: number} = JSON.parse(msg.data);
-                const diagnostic: SarifViewerDiagnostic | undefined = this.diagnosticCollection.getResultInfo(id.resultId, id.runId);
+                const diagnostic: SarifViewerVsCodeDiagnostic | undefined = this.diagnosticCollection.getResultInfo(id.resultId, id.runId);
                 if (!diagnostic) {
                     break;
                 }

--- a/src/SVDiagnosticCollection.ts
+++ b/src/SVDiagnosticCollection.ts
@@ -3,7 +3,7 @@
  */
 import { SVDiagnosticFactory } from  "./factories/SVDiagnosticFactory";
 import { Diagnostic, DiagnosticCollection, DiagnosticSeverity, languages, Range, Uri, Event, EventEmitter, Disposable } from "vscode";
-import { RunInfo, SarifViewerDiagnostic } from "./common/Interfaces";
+import { RunInfo } from "./common/Interfaces";
 import { ExplorerController } from "./ExplorerController";
 import { Utilities } from "./Utilities";
 import { SarifViewerVsCodeDiagnostic } from "./SarifViewerDiagnostic";
@@ -183,7 +183,7 @@ export class SVDiagnosticCollection implements Disposable {
      */
     public async mappingChanged(): Promise<void> {
         for (const key of this.issuesCollection.keys()) {
-            const issues: SarifViewerDiagnostic[] | undefined = this.issuesCollection.get(key);
+            const issues: SarifViewerVsCodeDiagnostic[] | undefined = this.issuesCollection.get(key);
             if (!issues) {
                 continue;
             }
@@ -306,7 +306,7 @@ export class SVDiagnosticCollection implements Disposable {
      * @param collection diagnostic collection to search for matching runids
      */
     private removeResults(runsToRemove: number[], collection: Map<string, SarifViewerVsCodeDiagnostic[]>): void {
-        let diagnosticsRemoved: SarifViewerDiagnostic[] = [];
+        let diagnosticsRemoved: SarifViewerVsCodeDiagnostic[] = [];
         for (const key of collection.keys()) {
             const diagnostics: SarifViewerVsCodeDiagnostic[] = collection.get(key) || [];
             for (let i: number = diagnostics.length - 1; i >= 0; i--) {

--- a/src/SarifViewerDiagnostic.ts
+++ b/src/SarifViewerDiagnostic.ts
@@ -3,11 +3,12 @@
  */
 
  import * as vscode from 'vscode';
-import { ResultInfo, SarifViewerDiagnostic } from './common/Interfaces';
+import { ResultInfo, RunInfo } from './common/Interfaces';
 import { Result } from 'sarif';
 
-export class SarifViewerVsCodeDiagnostic extends vscode.Diagnostic implements SarifViewerDiagnostic {
+export class SarifViewerVsCodeDiagnostic extends vscode.Diagnostic implements vscode.Diagnostic {
     public constructor(
+        public readonly runInfo: RunInfo,
         public readonly resultInfo: ResultInfo,
         public readonly rawResult: Result,
         range: vscode.Range,

--- a/src/common/Interfaces.d.ts
+++ b/src/common/Interfaces.d.ts
@@ -61,10 +61,6 @@ export interface Location {
     toJSON(this: Location, key: any, value: any): any
 }
 
-export interface SarifViewerDiagnostic extends Diagnostic {
-    resultInfo: ResultInfo;
-    rawResult: sarif.Result;
-}
 
 export interface RunInfo {
     additionalProperties?: { [key: string]: string };
@@ -216,7 +212,7 @@ export interface WebviewMessage {
 export interface DiagnosticData {
     activeTab?: any,
     resultInfo: ResultInfo,
-    runInfo?: RunInfo,
+    runInfo: RunInfo,
     selectedRow?: string,
     selectedVerbosity?: any
 }

--- a/src/explorer/webview.ts
+++ b/src/explorer/webview.ts
@@ -47,7 +47,7 @@ export class ExplorerWebview {
         postMessage: (message: WebviewMessage) => void;
     };
 
-    public diagnostic?: DiagnosticData;
+    public diagnostic: DiagnosticData | undefined;
 
     private hasCodeFlows: boolean = false;
     private hasAttachments: boolean = false;
@@ -1267,22 +1267,29 @@ export class ExplorerWebview {
      */
     private setDiagnostic(data: string): void {
         this.cleanUpResultDetails();
-        const diagnosticData: DiagnosticData = JSON.parse(data);
-        this.diagnostic = diagnosticData;
+
+        // Zero-length data string means no activate diagnostic
+        const newDiagnosticData: DiagnosticData | undefined = data.length !== 0 ? JSON.parse(data) : undefined;
+        this.diagnostic = newDiagnosticData;
+
+        if (!newDiagnosticData) {
+            return;
+        }
+
         this.loadResultDetails();
 
-        if (diagnosticData.selectedRow !== undefined) {
-            this.showTreeNode(diagnosticData.selectedRow, true);
+        if (newDiagnosticData.selectedRow !== undefined) {
+            this.showTreeNode(newDiagnosticData.selectedRow, true);
         }
 
-        if (diagnosticData.activeTab !== undefined) {
-            this.openTab(diagnosticData.activeTab);
+        if (newDiagnosticData.activeTab !== undefined) {
+            this.openTab(newDiagnosticData.activeTab);
         }
 
-        if (diagnosticData.selectedVerbosity !== undefined) {
+        if (newDiagnosticData.selectedVerbosity !== undefined) {
             const codeflowverbosity: HTMLInputElement | undefined = getOptionalDocumentElementById(document, "codeflowverbosity", HTMLInputElement);
             if (codeflowverbosity) {
-                codeflowverbosity.value = diagnosticData.selectedVerbosity;
+                codeflowverbosity.value = newDiagnosticData.selectedVerbosity;
                 this.updateTreeVerbosity();
             }
         }

--- a/src/factories/SVDiagnosticFactory.ts
+++ b/src/factories/SVDiagnosticFactory.ts
@@ -7,7 +7,6 @@ import { ResultInfoFactory } from "./ResultInfoFactory";
 import { CodeFlowFactory } from  "./CodeFlowFactory";
 import { DiagnosticSeverity } from "vscode";
 import { ResultInfo, Location, RunInfo } from "../common/Interfaces";
-import { SVDiagnosticCollection } from "../SVDiagnosticCollection";
 import { SarifViewerVsCodeDiagnostic } from "../SarifViewerDiagnostic";
 import { ExplorerController } from "../ExplorerController";
 
@@ -28,18 +27,16 @@ export namespace SVDiagnosticFactory {
      * @param resultInfo processed result info
      * @param rawResult sarif result info from the sarif file
      */
-    export function create(diagnosticCollection: SVDiagnosticCollection, resultInfo: ResultInfo, rawResult: sarif.Result): SarifViewerVsCodeDiagnostic {
+    export function create(runInfo: RunInfo, resultInfo: ResultInfo, rawResult: sarif.Result): SarifViewerVsCodeDiagnostic {
         if (!resultInfo.assignedLocation ||
             !resultInfo.message.text) {
             throw new Error('Cannot represent a diagnostic without a range in the document and the diagnostic text to display to the user.');
         }
 
-        const svDiagnostic: SarifViewerVsCodeDiagnostic = new SarifViewerVsCodeDiagnostic(resultInfo, rawResult, resultInfo.assignedLocation.range, resultInfo.message.text);
+        const svDiagnostic: SarifViewerVsCodeDiagnostic = new SarifViewerVsCodeDiagnostic(runInfo, resultInfo, rawResult, resultInfo.assignedLocation.range, resultInfo.message.text);
         svDiagnostic.severity = SVDiagnosticFactory.getSeverity(resultInfo.severityLevel);
         svDiagnostic.code = resultInfo.ruleId;
-
-        const runInfo: RunInfo | undefined = diagnosticCollection.getRunInfo(resultInfo.runId);
-        svDiagnostic.source = runInfo ? runInfo.toolName : "Unknown tool";
+        svDiagnostic.source = runInfo.toolName || "Unknown tool";
 
         svDiagnostic.message = SVDiagnosticFactory.updateMessage(svDiagnostic);
 

--- a/tsconfig.explorer.json
+++ b/tsconfig.explorer.json
@@ -21,7 +21,6 @@
         "noUnusedParameters": false,  /* Report errors on unused parameters. */
         "checkJs": true,
         "noImplicitThis": true,
-        "strictNullChecks": true
     },
     "include": [
         "src/explorer/*.ts"


### PR DESCRIPTION
When this PR was completed #211, a new concept of the "vscode diagnostic" was introduced that was intended to replace the one in "common interfaces".

This was discovered while trying to "decouple" some of the "data model" concepts from the UI. For example, the current implementation of the extension passes around the "Explorer controller" pretty much everywhere. Typically the instance of explorer controller is merely used to "look up" things like the "run info" from a "result" or an ID. That simply won't be needed if we add back-pointers to data in appropriate places. The VSCode diagnostic was one of these cases.

This also addresses the case where no diagnostic is selected that the web-view wasn't properly notified of it.