### PR TITLE
Collect standard error while running the conversion tool.

### DIFF
--- a/src/FileConverter.ts
+++ b/src/FileConverter.ts
@@ -199,9 +199,13 @@ export class FileConverter {
         const fileOutputPath: string = output;
         const errorData: string[] = [];
         const converted: boolean = await new Promise<boolean>((resolve) => {
-            const proc: ChildProcess = spawn(multiToolPath,
-                ["transform", doc.uri.fsPath, "-o", fileOutputPath, "-p", "-f"],
-            );
+            const launchMultiToolPath: string = multiToolPath;
+            const args: string[] = ["transform", `"${doc.uri.fsPath}"`, "-o", `"${fileOutputPath}"`, "-p", "-f"];
+            const proc: ChildProcess = spawn(launchMultiToolPath, args);
+
+            proc.stderr.on("data", (data) => {
+                errorData.push(data.toString());
+            });
 
             proc.stdout.on("data", (data) => {
                 errorData.push(data.toString());

--- a/src/FileConverter.ts
+++ b/src/FileConverter.ts
@@ -199,9 +199,7 @@ export class FileConverter {
         const fileOutputPath: string = output;
         const errorData: string[] = [];
         const converted: boolean = await new Promise<boolean>((resolve) => {
-            const launchMultiToolPath: string = multiToolPath;
-            const args: string[] = ["transform", `"${doc.uri.fsPath}"`, "-o", `"${fileOutputPath}"`, "-p", "-f"];
-            const proc: ChildProcess = spawn(launchMultiToolPath, args);
+            const proc: ChildProcess = spawn(multiToolPath, ["transform", `"${doc.uri.fsPath}"`, "-o", `"${fileOutputPath}"`, "-p", "-f"]);
 
             proc.stderr.on("data", (data) => {
                 errorData.push(data.toString());

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -186,7 +186,7 @@ export class Utilities {
             path.join(pathObj.dir.replace(pathObj.root, ""), path.win32.basename(filePath)));
         tempPath = tempPath.split("#").join(""); // remove the #s to not create a folder structure with fragments
         basePath = Utilities.createDirectoryInTemp(basePath);
-        tempPath = path.posix.join(basePath, tempPath);
+        tempPath = path.join(basePath, tempPath);
 
         return tempPath;
     }


### PR DESCRIPTION
Quick fix to address issue #226.

When running the conversion tool, the viewer was not collecting all of the information from "standard error". As such, the user would see "Sarif upgrade failed with error:" with nothing else.