### PR TITLE
Remove system JS, fix issues with importing large files, and select the proper diagnostic during code navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1053,11 +1053,6 @@
                 "has-flag": "^3.0.0"
             }
         },
-        "systemjs": {
-            "version": "6.2.5",
-            "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.2.5.tgz",
-            "integrity": "sha512-Jw1FOgzxG+wIi+ewEPyYKsqxR3IQOQWMwFh1o7C0VfLYoBcVDYSg8EFrKCisUD+5+/KecrDC+NSy4exkl7QRdw=="
-        },
         "tslib": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -210,7 +210,6 @@
         "json-source-map": "^0.4.0",
         "jsonpointer": "4.0.1",
         "markdown-it": "^9.0.1",
-        "systemjs": "^6.2.5",
         "requirejs": "^2.3.6",
         "@microsoft/sarif-multitool": "2.2.2"
     }

--- a/src/ExplorerController.ts
+++ b/src/ExplorerController.ts
@@ -206,7 +206,6 @@ export class ExplorerController implements Disposable {
             <link rel="stylesheet" type="text/css" href = "${cssListTableDiskPath}">
             <link rel="stylesheet" type="text/css" href = "${cssExplorerDiskPath}">
             <link rel="stylesheet" type="text/css" href = "${cssResultsListDiskPath}">
-            <srcipt src="./node_modules/systemjs/dist/system.js"></script>
             <script src="${jQueryDiskPath}"></script>
             <script src="${colResizeDiskPath}"></script>
             <script data-main="${explorerPath}" src="${requireJsPath}"></script>

--- a/src/FileConverter.ts
+++ b/src/FileConverter.ts
@@ -200,7 +200,10 @@ export class FileConverter {
         const fileOutputPath: string = output;
         const errorData: string[] = [];
         const converted: boolean = await new Promise<boolean>((resolve) => {
-            const proc: ChildProcess = spawn(multiToolPath, ["transform", `"${doc.uri.fsPath}"`, "-o", `"${fileOutputPath}"`, "-p", "-f"]);
+            // If you are tempted to put quotes around these strings, please don't as "spawn" does that internally.
+            // Something to consider is adding an option to the SARIF viewr so the path to the multi-tool
+            // can be over-ridden for testing.
+            const proc: ChildProcess =  spawn(multiToolPath, ["transform", doc.uri.fsPath, "-o", fileOutputPath, "-p", "-f"]);
 
             proc.stderr.on("data", (data) => {
                 errorData.push(data.toString());

--- a/src/ResultsListController.ts
+++ b/src/ResultsListController.ts
@@ -171,6 +171,10 @@ export class ResultsListController implements Disposable {
                 }
 
                 const textDocument: TextDocument = await workspace.openTextDocument(uriToOpen);
+
+                // This could be an option. There have issues that have been raised that when you
+                // click on results in the web-view (explorer) that focus is taken away from it and
+                // placed on the document. Some users may want this, some may not.
                 const preserveFocus: boolean = window.activeTextEditor !== undefined;
                 const textEditor: TextEditor = await window.showTextDocument(textDocument, ViewColumn.One, preserveFocus);
                 textEditor.revealRange(diagLocation.range, TextEditorRevealType.InCenterIfOutsideViewport);


### PR DESCRIPTION
This address issue #225, where the result-pane cannot scroll and as the user moves through the source code document the selection does not always cause the correct diagnostic to be selected. This was due to the fact that the "location ranges" in SARIF are largey "empty" (or a single point). So if you manage to put the cursor "just right" in VSCode then it would select. This has been addressed by seeing if the range is "empty" and "single line" and if it is, then just match on the line.

The issue with the result-pane not scrolling (and being empty some times) was due to code that was accidentally left in when trying to find a java-script module loader that would work in vscode's WebView. For note: RequireJS works fine, SystemJS, not so much :). I forget to remove some of the SystemJS code. That was PR #211 

Also, for future referece, when you call spawn in node, it automatically quotes parameters. (Ugh). I thought that was an issue that was causing the multi-tool converter to fail, which I later found is not the cause, it is due to missing .Net dependencies (ugh).