### PR TITLE
Add a simple way for the SARIF-SDK multi-tool path to be overridden

### DIFF
--- a/src/FileConverter.ts
+++ b/src/FileConverter.ts
@@ -201,9 +201,7 @@ export class FileConverter {
         const errorData: string[] = [];
         const converted: boolean = await new Promise<boolean>((resolve) => {
             // If you are tempted to put quotes around these strings, please don't as "spawn" does that internally.
-            // Something to consider is adding an option to the SARIF viewr so the path to the multi-tool
-            // can be over-ridden for testing.
-            const proc: ChildProcess =  spawn(multiToolPath, ["transform", doc.uri.fsPath, "-o", fileOutputPath, "-p", "-f"]);
+            const proc: ChildProcess =  spawn(FileConverter.pathToMulitTool, ['transform', doc.uri.fsPath, '-o', fileOutputPath, '-p', '-f']);
 
             proc.stderr.on("data", (data) => {
                 errorData.push(data.toString());
@@ -270,9 +268,9 @@ export class FileConverter {
      * @param tool tool that generated the file to convert
      */
     private static convert(uri: vscode.Uri, tool: string): void {
-        const output: string = Utilities.generateTempPath(uri.fsPath) + ".sarif";
-        const proc: ChildProcess = spawn(multiToolPath,
-            ["convert", "-t", tool, "-o", output, "-p", "-f", uri.fsPath],
+        const output: string = `${Utilities.generateTempPath(uri.fsPath)}.sarif`;
+        const proc: ChildProcess = spawn(FileConverter.pathToMulitTool,
+            ['convert', '-t', tool, '-o', output, '-p', '-f', uri.fsPath],
         );
 
         proc.on("close", async (code) => {
@@ -379,5 +377,14 @@ export class FileConverter {
         const rawSchemaVersion: string = matchArray[0].replace(".json", "");
 
         return FileConverter.parseVersion(rawSchemaVersion);
+    }
+
+    /**
+     * Returns the path to the multi-tool.
+     * The path can be overridden by setting 'sarifViewer.multiToolPath'
+     * in the process environment.
+     */
+    private static get pathToMulitTool(): string {
+        return process.env['sarifViewer.multiToolPath'] || multiToolPath;
     }
 }

--- a/src/FileConverter.ts
+++ b/src/FileConverter.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import { SarifVersion } from "./common/Interfaces";
 import { Utilities } from "./Utilities";
 import { ChildProcess, spawn } from "child_process";
-import multiToolPath from "@microsoft/sarif-multitool";
+import * as nodeModulesMultiToolPath from "@microsoft/sarif-multitool";
 
 /**
  * Handles converting a non sarif static analysis file to a sarif file via the sarif-sdk multitool
@@ -17,7 +17,7 @@ export class FileConverter {
         FileConverter.registerCommands(extensionContext);
     }
 
-    private  static registerCommands(extensionContext: vscode.ExtensionContext): void {
+    private static registerCommands(extensionContext: vscode.ExtensionContext): void {
         extensionContext.subscriptions.push(
             vscode.commands.registerCommand("extension.sarif.Convert", FileConverter.selectConverter),
         );
@@ -201,7 +201,7 @@ export class FileConverter {
         const errorData: string[] = [];
         const converted: boolean = await new Promise<boolean>((resolve) => {
             // If you are tempted to put quotes around these strings, please don't as "spawn" does that internally.
-            const proc: ChildProcess =  spawn(FileConverter.pathToMulitTool, ['transform', doc.uri.fsPath, '-o', fileOutputPath, '-p', '-f']);
+            const proc: ChildProcess =  spawn(FileConverter.multiToolPath, ['transform', doc.uri.fsPath, '-o', fileOutputPath, '-p', '-f']);
 
             proc.stderr.on("data", (data) => {
                 errorData.push(data.toString());
@@ -269,7 +269,7 @@ export class FileConverter {
      */
     private static convert(uri: vscode.Uri, tool: string): void {
         const output: string = `${Utilities.generateTempPath(uri.fsPath)}.sarif`;
-        const proc: ChildProcess = spawn(FileConverter.pathToMulitTool,
+        const proc: ChildProcess = spawn(FileConverter.multiToolPath,
             ['convert', '-t', tool, '-o', output, '-p', '-f', uri.fsPath],
         );
 
@@ -384,7 +384,7 @@ export class FileConverter {
      * The path can be overridden by setting 'sarifViewer.multiToolPath'
      * in the process environment.
      */
-    private static get pathToMulitTool(): string {
-        return process.env['sarifViewer.multiToolPath'] || multiToolPath;
+    private static get multiToolPath(): string {
+        return process.env['sarifViewer.multiToolPath'] || nodeModulesMultiToolPath;
     }
 }


### PR DESCRIPTION
This address issue #230. Currently the multi-tool converter is not working correctly on certain machines when used from the NPM package. @michaelcfanning is looking into that.

In order to unblock, well, myself and potentially others, this PR adds the ability to override the path to the "mulit-tool" in the process environment block. This will allow testing of changes of the SDK with versions of the extensions that have already been published to the market place as well.

I considered a user option, but, we probably don't want to easily expose this as a user setting.