### PR TITLE
Scroll the selected result into view and expand its group

### DIFF
--- a/src/FileConverter.ts
+++ b/src/FileConverter.ts
@@ -203,7 +203,7 @@ export class FileConverter {
             // If you are tempted to put quotes around these strings, please don't as "spawn" does that internally.
             // Something to consider is adding an option to the SARIF viewr so the path to the multi-tool
             // can be over-ridden for testing.
-            const proc: ChildProcess =  spawn(multiToolPath, ["transform", doc.uri.fsPath, "-o", fileOutputPath, "-p", "-f"]);
+            const proc: ChildProcess =  spawn("d:\\Gabriel\\Documents\\Repos\\sarif-sdk\\bld\\bin\\AnyCPU_Debug\\Sarif.Multitool\\net461\\Sarif.Multitool.exe", ["transform", doc.uri.fsPath, "-o", fileOutputPath, "-p", "-f"]);
 
             proc.stderr.on("data", (data) => {
                 errorData.push(data.toString());

--- a/src/explorer/resultsList.ts
+++ b/src/explorer/resultsList.ts
@@ -99,11 +99,14 @@ export class ResultsList {
             curSelected[0].classList.remove("selected");
         }
 
-        const rows: HTMLCollectionOf<HTMLElement> = <HTMLCollectionOf<HTMLElement>>document.getElementsByClassName("listtablerow");
+        const rows: HTMLCollectionOf<HTMLTableRowElement> = <HTMLCollectionOf<HTMLTableRowElement>>document.getElementsByClassName("listtablerow");
         // @ts-ignore: compiler complains even though results can be iterated
         for (const row of rows) {
             if (row.dataset.id === id) {
                 row.classList.add("selected");
+                this.expandGroupForResult(row);
+                row.scrollIntoView();
+                break;
             }
         }
     }
@@ -617,6 +620,31 @@ export class ResultsList {
                 } else {
                     result.classList.remove("hidden");
                 }
+            }
+        }
+    }
+
+    /**
+     * Toggles the group row as well as any result rows that match the group
+     * @param row Group row to toggled
+     */
+    private expandGroupForResult(row: HTMLTableRowElement): void {
+
+        if (row.dataset.group === undefined) {
+            throw new Error("Expected to have collapse group.");
+        }
+
+        if (row.classList.contains(`${ToggleState.collapsed}`)) {
+            row.classList.replace(`${ToggleState.collapsed}`, `${ToggleState.expanded}`);
+            this.collapsedGroups.splice(this.collapsedGroups.indexOf(row.dataset.group), 1);
+        }
+
+        const results: NodeListOf<Element> = document.querySelectorAll("#resultslisttable > tbody > .listtablerow");
+
+        for (const result of results) {
+            // @ts-ignore: compiler complains even though result does have a dataset
+            if (result.dataset.group === row.dataset.group) {
+                result.classList.remove("hidden");
             }
         }
     }

--- a/src/explorer/resultsList.ts
+++ b/src/explorer/resultsList.ts
@@ -600,12 +600,12 @@ export class ResultsList {
         }
 
         let hideRow: boolean = false;
-        if (row.classList.contains(`${ToggleState.expanded}`)) {
-            row.classList.replace(`${ToggleState.expanded}`, `${ToggleState.collapsed}`);
+        if (row.classList.contains(ToggleState.expanded)) {
+            row.classList.replace(ToggleState.expanded, ToggleState.collapsed);
             this.collapsedGroups.push(row.dataset.group);
             hideRow = true;
         } else {
-            row.classList.replace(`${ToggleState.collapsed}`, `${ToggleState.expanded}`);
+            row.classList.replace(ToggleState.collapsed, ToggleState.expanded);
             this.collapsedGroups.splice(this.collapsedGroups.indexOf(row.dataset.group), 1);
         }
 
@@ -634,8 +634,8 @@ export class ResultsList {
             throw new Error("Expected to have collapse group.");
         }
 
-        if (row.classList.contains(`${ToggleState.collapsed}`)) {
-            row.classList.replace(`${ToggleState.collapsed}`, `${ToggleState.expanded}`);
+        if (row.classList.contains(ToggleState.collapsed)) {
+            row.classList.replace(ToggleState.collapsed, ToggleState.expanded);
             this.collapsedGroups.splice(this.collapsedGroups.indexOf(row.dataset.group), 1);
         }
 


### PR DESCRIPTION
This address issue #233 
While testing the extension with a large number of results, it become readily apparent that when the user is navigating through the source code (which causes results to be selected in the viewer), the viewer did not expand or scroll the result into view (even though it was selected).

This is a quick fix to address that while @jeffersonking is working on improvements to the viewer. 