### PR TITLE
Do not alias the default import

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,10 +207,10 @@
         "tslint-no-unused-expression-chai": "^0.1.4"
     },
     "dependencies": {
+        "@microsoft/sarif-multitool": "^2.2.2",
         "json-source-map": "^0.4.0",
         "jsonpointer": "4.0.1",
         "markdown-it": "^9.0.1",
         "requirejs": "^2.3.6",
-        "@microsoft/sarif-multitool": "2.2.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -211,6 +211,6 @@
         "json-source-map": "^0.4.0",
         "jsonpointer": "4.0.1",
         "markdown-it": "^9.0.1",
-        "requirejs": "^2.3.6",
+        "requirejs": "^2.3.6"
     }
 }

--- a/src/FileConverter.ts
+++ b/src/FileConverter.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import { SarifVersion } from "./common/Interfaces";
 import { Utilities } from "./Utilities";
 import { ChildProcess, spawn } from "child_process";
-import * as nodeModulesMultiToolPath from "@microsoft/sarif-multitool";
+import multitoolPath from "@microsoft/sarif-multitool";
 
 /**
  * Handles converting a non sarif static analysis file to a sarif file via the sarif-sdk multitool
@@ -385,6 +385,6 @@ export class FileConverter {
      * in the process environment.
      */
     private static get multiToolPath(): string {
-        return process.env['sarifViewer.multiToolPath'] || nodeModulesMultiToolPath;
+        return process.env['sarifViewer.multiToolPath'] || multitoolPath;
     }
 }


### PR DESCRIPTION
When completing pull request #236 , I attempted to alias the default import with a different name so that the static property in the FileConverter did not have the same as the default import.

Unfortunately while testing, I still had the environment variable set so I wasn't actually using the alias.

While working with @michaelcfanning to figure out why the multi-tool isn't working from the NPM package on my machine, I unset the environment variable and realized the alias wasn't working as expected. Instead of returning a string, it was returning an object where all the path characters where individual characters rather than a string???? (I'll leave it to the javascript module exports to explain that one).

This change reverts the alias.