### PR TITLE
Turn on strict type predicate

### DIFF
--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -312,28 +312,31 @@ export interface ResultsListRow {
     sarifFile: ResultsListStringValue,
     severityLevel: ResultsListSeverityValue,
     tool: ResultsListStringValue,
-    readonly [key: string]: ResultsListValue | ResultsListStringValue | ResultsListNumberValue | ResultsListCustomOrderValue | ResultsListPositionValue;
+    readonly [key: string]: ResultsListStringValue | ResultsListNumberValue | ResultsListCustomOrderValue | ResultsListPositionValue | undefined;
 }
 
+export type ResultsListValueKind = 'Base' | 'String' | 'Number' | 'Position' | 'Custom Order';
 export interface ResultsListValue {
+    kind: ResultsListValueKind,
     value?: any,
     tooltip?: string,
 }
 
 export interface ResultsListStringValue extends ResultsListValue {
-    value?: string,
+    kind: 'String',
 }
 
 export interface ResultsListNumberValue extends ResultsListValue {
-    value?: number
+    kind: 'Number',
 }
 
 export interface ResultsListPositionValue extends ResultsListValue {
+    kind: 'Position',
     pos?: Position,
-    value?: string,
 }
 
 export interface ResultsListCustomOrderValue extends ResultsListValue {
+    kind: 'Custom Order',
     customOrderType : 'Baseline' | 'Kind' | 'Severity';
     order: BaselineOrder | KindOrder | SeverityLevelOrder,
     value?: sarif.Result.baselineState | sarif.Result.kind | sarif.Result.level,

--- a/src/common/resultValueHelpers.ts
+++ b/src/common/resultValueHelpers.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ */
+
+import { ResultsListValue, ResultsListPositionValue, ResultsListCustomOrderValue, ResultsListStringValue, ResultsListNumberValue } from "./interfaces";
+
+export function isResultsListPositionValue(value: ResultsListValue): value is ResultsListPositionValue {
+    return value.kind === 'Position';
+}
+
+export function isResultsListCustomOrderValue(value: ResultsListValue): value is ResultsListCustomOrderValue {
+    return value.kind === 'Custom Order';
+}
+
+export function isResultsListStringValue(value: ResultsListValue): value is ResultsListStringValue {
+    return value.kind === 'String';
+}
+
+export function isResultsListNumberValue(value: ResultsListValue): value is ResultsListNumberValue {
+    return value.kind === 'Number';
+}

--- a/src/factories/codeFlowFactory.ts
+++ b/src/factories/codeFlowFactory.ts
@@ -177,11 +177,9 @@ export namespace CodeFlowFactory {
             }
 
             if (tFLoc.nestingLevel !== undefined && nextTFLoc.nestingLevel !== undefined) {
-                if ((tFLoc.nestingLevel < nextTFLoc.nestingLevel) ||
-                (tFLoc.nestingLevel === undefined && nextTFLoc.nestingLevel !== undefined)) {
+                if (tFLoc.nestingLevel < nextTFLoc.nestingLevel) {
                     isParentFlag = true;
-                } else if (tFLoc.nestingLevel > nextTFLoc.nestingLevel ||
-                    (tFLoc.nestingLevel !== undefined && nextTFLoc.nestingLevel === undefined)) {
+                } else if (tFLoc.nestingLevel > nextTFLoc.nestingLevel) {
                     isLastChildFlag = true;
                 }
             }

--- a/src/factories/codeFlowFactory.ts
+++ b/src/factories/codeFlowFactory.ts
@@ -10,7 +10,7 @@ import { LocationFactory } from "./locationFactory";
 import { Command } from "vscode";
 import { CodeFlow, CodeFlowStep, CodeFlowStepId, Location, Message, ThreadFlow, RunInfo } from "../common/interfaces";
 import { Utilities } from "../utilities";
-import { sendCFSelectionToExplorerCommand } from "../CodeFlowDecorations";
+import { sendCFSelectionToExplorerCommand } from "../codeFlowDecorations";
 
 const threadFlowLocations: Map<string, sarif.ThreadFlowLocation> = new Map<string, sarif.ThreadFlowLocation>();
 

--- a/src/factories/locationFactory.ts
+++ b/src/factories/locationFactory.ts
@@ -151,41 +151,39 @@ export namespace LocationFactory {
         let endcol: number = 1;
         let eol: boolean = false;
 
-        if (region !== undefined) {
-            if (region.startLine !== undefined) {
-                startline = region.startLine - 1;
-                if (region.startColumn !== undefined) {
-                    startcol = region.startColumn - 1;
-                }
+        if (region.startLine !== undefined) {
+            startline = region.startLine - 1;
+            if (region.startColumn !== undefined) {
+                startcol = region.startColumn - 1;
+            }
 
-                if (region.endLine !== undefined) {
-                    endline = region.endLine - 1;
-                } else {
-                    endline = startline;
-                }
+            if (region.endLine !== undefined) {
+                endline = region.endLine - 1;
+            } else {
+                endline = startline;
+            }
 
-                if (region.endColumn !== undefined) {
-                    endcol = region.endColumn - 1;
-                } else if (region.snippet !== undefined) {
-                    if (region.snippet.text !== undefined) {
-                        endcol = region.snippet.text.length - 2;
-                    } else if (region.snippet.binary !== undefined) {
-                        endcol = Buffer.from(region.snippet.binary, 'base64').toString().length;
-                    }
-                } else {
-                    endline++;
-                    endcol = 0;
-                    eol = true;
+            if (region.endColumn !== undefined) {
+                endcol = region.endColumn - 1;
+            } else if (region.snippet !== undefined) {
+                if (region.snippet.text !== undefined) {
+                    endcol = region.snippet.text.length - 2;
+                } else if (region.snippet.binary !== undefined) {
+                    endcol = Buffer.from(region.snippet.binary, 'base64').toString().length;
                 }
-            } else if (region.charOffset !== undefined) {
-                startline = 0;
-                startcol = region.charOffset;
+            } else {
+                endline++;
+                endcol = 0;
+                eol = true;
+            }
+        } else if (region.charOffset !== undefined) {
+            startline = 0;
+            startcol = region.charOffset;
 
-                if (region.charLength !== undefined) {
-                    endcol = region.charLength + region.charOffset;
-                } else {
-                    endcol = startcol;
-                }
+            if (region.charLength !== undefined) {
+                endcol = region.charLength + region.charOffset;
+            } else {
+                endcol = startcol;
             }
         }
 

--- a/src/factories/resultInfoFactory.ts
+++ b/src/factories/resultInfoFactory.ts
@@ -330,7 +330,7 @@ export namespace ResultInfoFactory {
      */
     function checkFrameContent(frame: Frame, columnsWithContent: StackColumnWithContent): StackColumnWithContent {
         columnsWithContent.message = columnsWithContent.message && frame.message.text !== undefined && frame.message.text !== '';
-        columnsWithContent.name = columnsWithContent.name && frame.name !== undefined && frame.name !== '';
+        columnsWithContent.name = columnsWithContent.name && frame.name.length !== 0;
         columnsWithContent.location = columnsWithContent.location && frame.location.range.start.line !== 0;
         columnsWithContent.filename = columnsWithContent.filename && frame.location.fileName !== undefined && frame.location.fileName !== '';
         columnsWithContent.parameters = columnsWithContent.parameters && frame.parameters.length !== 0;

--- a/src/fileMapper.ts
+++ b/src/fileMapper.ts
@@ -137,7 +137,7 @@ export class FileMapper implements Disposable {
             this.addToFileMapping(Utilities.getFsPathWithFragment(origUri), uri);
             this.saveBasePath(origUri, uri, uriBase);
             this.fileRemapping.forEach((value: Uri | undefined, key: string) => {
-                if (value === null) {
+                if (value) {
                     this.tryRebaseUri(Uri.file(key));
                 }
             });

--- a/src/fileMapper.ts
+++ b/src/fileMapper.ts
@@ -137,7 +137,7 @@ export class FileMapper implements Disposable {
             this.addToFileMapping(Utilities.getFsPathWithFragment(origUri), uri);
             this.saveBasePath(origUri, uri, uriBase);
             this.fileRemapping.forEach((value: Uri | undefined, key: string) => {
-                if (value) {
+                if (!value) {
                     this.tryRebaseUri(Uri.file(key));
                 }
             });

--- a/src/resultsListController.ts
+++ b/src/resultsListController.ts
@@ -10,8 +10,7 @@ import {
 } from "vscode";
 import { BaselineOrder, KindOrder, MessageType, SeverityLevelOrder } from "./common/enums";
 import {
-    ResultInfo, ResultsListColumn, ResultsListCustomOrderValue, ResultsListData, ResultsListGroup,
-    ResultsListPositionValue, ResultsListRow, ResultsListSortBy, ResultsListValue,
+    ResultInfo, ResultsListColumn, ResultsListData, ResultsListGroup, ResultsListRow, ResultsListSortBy, ResultsListValue,
     WebviewMessage, Location, RunInfo
 } from "./common/interfaces";
 import { ExplorerController } from "./explorerController";
@@ -19,6 +18,7 @@ import { SVCodeActionProvider } from "./svCodeActionProvider";
 import { SVDiagnosticCollection, SVDiagnosticsChangedEvent } from "./svDiagnosticCollection";
 import { Utilities } from "./utilities";
 import { SarifViewerVsCodeDiagnostic } from "./sarifViewerDiagnostic";
+import { isResultsListPositionValue, isResultsListCustomOrderValue, isResultsListStringValue, isResultsListNumberValue } from './common/resultValueHelpers';
 
 /**
  * Class that acts as the data controller for the ResultsList in the Sarif Explorer
@@ -343,22 +343,22 @@ export class ResultsListController implements Disposable {
         }
 
         return {
-            baselineState: { customOrderType: 'Baseline', order: baselineOrder, value: resultInfo.baselineState },
-            kind: { customOrderType: 'Kind', order: kindOrder, value: resultInfo.kind },
-            severityLevel: { customOrderType: 'Severity', order: sevOrder, value: resultInfo.severityLevel },
-            message: { value: resultInfo.message.text },
-            resultStartPos:  {pos: startPosition, value: startPositionString },
-            resultId: { value: resultInfo.id },
-            ruleId: { value: resultInfo.ruleId },
-            ruleName: { value: resultInfo.ruleName },
-            runId: { value: resultInfo.runId },
-            automationCat: { value: run && run.automationCategory },
-            automationId:  { value: run && run.automationIdentifier },
-            sarifFile: { value: run && run.sarifFileName, tooltip: run && run.sarifFileFullPath },
-            tool: { value: run && run.toolName, tooltip: run && run.toolFullName },
-            resultFile: { tooltip: resultFsPath, value: resultFileName },
-            logicalLocation: { value: logicalLocation },
-            rank: { value: resultInfo.rank },
+            baselineState: { kind: 'Custom Order', customOrderType: 'Baseline', order: baselineOrder, value: resultInfo.baselineState },
+            kind: { kind: 'Custom Order', customOrderType: 'Kind', order: kindOrder, value: resultInfo.kind },
+            severityLevel: { kind: 'Custom Order', customOrderType: 'Severity', order: sevOrder, value: resultInfo.severityLevel },
+            message: { kind: 'String', value: resultInfo.message.text },
+            resultStartPos:  {kind: 'Position', pos: startPosition, value: startPositionString },
+            resultId: { kind: 'Number', value: resultInfo.id },
+            ruleId: { kind: 'String', value: resultInfo.ruleId },
+            ruleName: { kind: 'String', value: resultInfo.ruleName },
+            runId: { kind: 'Number', value: resultInfo.runId },
+            automationCat: { kind: 'String', value: run && run.automationCategory },
+            automationId:  { kind: 'String', value: run && run.automationIdentifier },
+            sarifFile: { kind: 'String', value: run && run.sarifFileName, tooltip: run && run.sarifFileFullPath },
+            tool: { kind: 'String', value: run && run.toolName, tooltip: run && run.toolFullName },
+            resultFile: { kind: 'String', tooltip: resultFsPath, value: resultFileName },
+            logicalLocation: { kind: 'String', value: logicalLocation },
+            rank: { kind: 'Number', value: resultInfo.rank },
         };
     }
 
@@ -440,7 +440,11 @@ export class ResultsListController implements Disposable {
                 continue;
             }
 
-            const resultsListValue: ResultsListValue = row[this.groupBy];
+            const resultsListValue: ResultsListValue | undefined = row[this.groupBy];
+            if (!resultsListValue) {
+                continue;
+            }
+
             // tslint:disable-next-line: no-any
             let key: any = resultsListValue.value;
 
@@ -469,9 +473,9 @@ export class ResultsListController implements Disposable {
         // sort rows in each group
         for (const group of data.groups) {
             group.rows.sort((a, b) => {
-                let comp: number;
-                let valueA: ResultsListValue;
-                let valueB: ResultsListValue;
+                let comp: number = 0;
+                let valueA: ResultsListValue | undefined;
+                let valueB: ResultsListValue | undefined;
                 if (this.sortBy.ascending) {
                     valueA = a[this.sortBy.column];
                     valueB = b[this.sortBy.column];
@@ -480,26 +484,29 @@ export class ResultsListController implements Disposable {
                     valueB = a[this.sortBy.column];
                 }
 
-                if (valueA === undefined || valueA.value === undefined) {
-                    comp = -1;
-                    if (valueB === undefined || valueB.value === undefined) {
+                if (valueA === undefined ||
+                    valueA.value === undefined ||
+                    valueB === undefined ||
+                    valueB.value === undefined) {
+                    if ((valueA === undefined || valueA.value === undefined) && (valueB === undefined || valueB.value === undefined)) {
                         comp = 0;
+                    } else if (valueB === undefined || valueB.value === undefined) {
+                        comp = 1;
+                    } else {
+                        comp = -1;
                     }
-                } else if (valueB === undefined || valueB.value === undefined) {
-                    comp = 1;
-                } else if ((valueA as ResultsListPositionValue).pos !== undefined && (valueB as ResultsListPositionValue).pos !== undefined) {
-                    const posA: Position = (valueA as ResultsListPositionValue).pos!;
-                    const posB: Position = (valueB as ResultsListPositionValue).pos!;
+                } else if (isResultsListPositionValue(valueA) && isResultsListPositionValue(valueB)) {
+                    const posA: Position = valueA.pos || new Position(0, 0);
+                    const posB: Position = valueB.pos || new Position(0, 0);
                     comp = posA.line - posB.line;
                     if (comp === 0) {
                         comp = posA.character - posB.character;
                     }
-                } else if ((valueA as ResultsListCustomOrderValue).order !== undefined) {
-                    comp = (valueA as ResultsListCustomOrderValue).order -
-                        (valueB as ResultsListCustomOrderValue).order;
-                } else if (typeof valueA.value === 'number') {
+                } else if (isResultsListCustomOrderValue(valueA) && isResultsListCustomOrderValue(valueB)) {
+                    comp = valueA.order - valueB.order;
+                } else if (isResultsListNumberValue(valueA) && isResultsListNumberValue(valueB)) {
                     comp = valueA.value - valueB.value;
-                } else {
+                } else if (isResultsListStringValue(valueA) && isResultsListStringValue(valueB)) {
                     comp = valueA.value.localeCompare(valueB.value);
                 }
 

--- a/src/resultsListController.ts
+++ b/src/resultsListController.ts
@@ -436,10 +436,6 @@ export class ResultsListController implements Disposable {
                 continue;
             }
 
-            if (!this.groupBy) {
-                continue;
-            }
-
             const resultsListValue: ResultsListValue | undefined = row[this.groupBy];
             if (!resultsListValue) {
                 continue;
@@ -484,13 +480,18 @@ export class ResultsListController implements Disposable {
                     valueB = a[this.sortBy.column];
                 }
 
-                if (valueA === undefined ||
-                    valueA.value === undefined ||
-                    valueB === undefined ||
-                    valueB.value === undefined) {
-                    if ((valueA === undefined || valueA.value === undefined) && (valueB === undefined || valueB.value === undefined)) {
+                if (valueA === undefined || valueB === undefined) {
+                    if (valueA === undefined && valueB === undefined) {
                         comp = 0;
-                    } else if (valueB === undefined || valueB.value === undefined) {
+                    } else if (valueB === undefined) {
+                        comp = 1;
+                    } else {
+                        comp = -1;
+                    }
+                } else if (valueA.value === undefined || valueB.value === undefined) {
+                    if (valueA.value === undefined && valueB.value === undefined) {
+                        comp = 0;
+                    } else if (valueB.value === undefined) {
                         comp = 1;
                     } else {
                         comp = -1;

--- a/tslint.json
+++ b/tslint.json
@@ -81,7 +81,7 @@
         "member-ordering": false,
         "no-parameter-properties": false,
         "no-inferrable-types": false,
-        "strict-type-predicates": false,
+        "strict-type-predicates": true,
         "increment-decrement": [true, "allow-post"],
         "no-implicit-dependencies": false,
         "ordered-imports": false,


### PR DESCRIPTION
Starts to address issue #242. Turns on "strict type predicate" which performs linting operations such as verifying that "if" conditions for "undefined" or against "types" do not evaluate to constant true or false expressions.