### PR TITLE
Fix lint error since $schema was already verified in the preceeding code

### DIFF
--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -169,7 +169,7 @@ export class FileConverter {
         // {
         //   "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
         //
-        const parsedSchemaVersion: SarifVersion | undefined = sarifLog.$schema !== undefined ? FileConverter.parseSchema(schemaUri) : undefined;
+        const parsedSchemaVersion: SarifVersion | undefined = FileConverter.parseSchema(schemaUri);
         if (!parsedSchemaVersion) {
             return {
                 upgradedNeeded: 'Could Not Parse Schema',


### PR DESCRIPTION
The build pipeline failed due to a lint error since  sarifLog.$schema was already verified to be non-null a few lines above.

Investigating why the build pipeline didn't catch this before allowing PR to complete.