### PR TITLE
Expose API for other plugins to drive the SARIF viewer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
     },
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
-    }
+    },
+    "cSpell.words": [
+        "SARIF"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -195,6 +195,14 @@
                 "command": "extension.sarif.previousCodeFlowStep",
                 "title": "%commands.extension.sarif.previousCodeFlowStep.title%",
                 "category": "%commands.category%"
+            },
+            {
+                "command": "extension.sarif.openLogFiles",
+                "title": "%commands.extension.sarif.openeLogFiles"
+            },
+            {
+                "command": "extension.sarif.closeLogFiles",
+                "title": "%commands.extension.sarif.closeLogFiles"
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -195,14 +195,6 @@
                 "command": "extension.sarif.previousCodeFlowStep",
                 "title": "%commands.extension.sarif.previousCodeFlowStep.title%",
                 "category": "%commands.category%"
-            },
-            {
-                "command": "extension.sarif.openLogFiles",
-                "title": "%commands.extension.sarif.openeLogFiles"
-            },
-            {
-                "command": "extension.sarif.closeLogFiles",
-                "title": "%commands.extension.sarif.closeLogFiles"
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
         "tslint": "^6.1.1"
     },
     "dependencies": {
-        "@microsoft/sarif-multitool": "^2.2.2",
+        "@microsoft/sarif-multitool": "^2.2.3",
         "json-source-map": "^0.4.0",
         "jsonpointer": "4.0.1",
         "markdown-it": "^9.0.1",

--- a/package.nls.json
+++ b/package.nls.json
@@ -42,7 +42,7 @@
     "converterTool.AllFiles": "All Files",
     "converterTool.OpenFileDialogTitle": "{0} log files",
 
-    "converterTool.UpgraderErrorMessage": "Sarif version '{0}'(schema '{1}') is not yet supported by the Viewer. Make sure you have the latest extension version and check https://github.com/Microsoft/sarif-vscode-extension for future support.`",
+    "converterTool.UpgradedErrorMessage": "Sarif version '{0}'(schema '{1}') is not yet supported by the Viewer. Make sure you have the latest extension version and check https://github.com/Microsoft/sarif-vscode-extension for future support.`",
     "converterTool.Upgrade.SaveTemp": "Yes (Save Temp)",
     "converterTool.Upgrade.SaveAs": "Yes (Save As)",
     "converterTool.Upgrade.No": "No",
@@ -59,10 +59,10 @@
     "openRemappingInputDialog.openDialogLabel": "Map",
     "openRemappingInputDialog.alreadyExistsInRoot": "'{0}' already exists in the settings (sarif-viewer.rootpaths), please try a different path (Press 'Escape' to cancel)",
 
-    "logReader.proecssingTitle": "Processing {0}",
+    "logReader.processingTitle": "Processing {0}",
     "logReader.processingSarifFile": "Parsing Sarif file",
     "logReader.jsonFileReadingError": "Sarif Viewer: Cannot display results for '{0}' because: {1}",
-    "logReader.schemaNotDefined": "Sarif Viewer: Cannot display results for '{0}' because the shema was not defined.",
+    "logReader.schemaNotDefined": "Sarif Viewer: Cannot display results for '{0}' because the schema was not defined.",
     "logReader.loadingResults": "Loading {0} Results",
     "logReader.loadingResultsPercentage": "Loading {0} Results: {1}% completed`",
 
@@ -105,8 +105,8 @@
 
     "resultInfoFactory.noMessageProvided": "No Message Provided",
 
-    "daignostic.noMessage": "No message",
-    "daignostic.unknownTool": "Unknown tool",
+    "diagnostic.noMessage": "No message",
+    "diagnostic.unknownTool": "Unknown tool",
 
     "codeFlowFactory.returnCall": "[return call]",
     "codeFlowFactory.noDescription": "[no description]",
@@ -115,7 +115,7 @@
     "time.hours": "{0} hrs",
     "time.hour": "{0} hr",
     "time.minutes": "{0} mins",
-    "time.minnute": "{0} min",
+    "time.minute": "{0} min",
     "time.seconds": "{0} secs",
     "time.second": "{0} sec",
     "time.none": "0 ms",

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,6 +23,8 @@
     "commands.extension.sarif.LaunchExplorer.title": "Launch the Sarif Explorer",
     "commands.extension.sarif.nextCodeFlowStep.title": "Next Code Flow step",
     "commands.extension.sarif.previousCodeFlowStep.title": "Previous Code Flow step",
+    "commands.extension.sarif.closeLogFiles": "Close log files",
+    "commands.extension.sarif.openLogFiles": "Open log files",
 
     "explorer.Title": "SARIF Explorer",
 

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,8 +23,6 @@
     "commands.extension.sarif.LaunchExplorer.title": "Launch the Sarif Explorer",
     "commands.extension.sarif.nextCodeFlowStep.title": "Next Code Flow step",
     "commands.extension.sarif.previousCodeFlowStep.title": "Previous Code Flow step",
-    "commands.extension.sarif.closeLogFiles": "Close log files",
-    "commands.extension.sarif.openLogFiles": "Open log files",
 
     "explorer.Title": "SARIF Explorer",
 

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * The expected arguments for the @see openLogFileCommand.
+ */
+export interface OpenLogFileArguments {
+    /**
+     * The array of SARIF log files to open. The log file URIs must be of scheme 'file' and be valid SARIF JSON files.
+     */
+    readonly sarifFiles: vscode.Uri[];
+
+    /**
+     * Specifies options indicating whether to prompt the user when the
+     * SARIF log file shcmea is needs to be ugpraded to the latest one.
+     * If not specified, the user will be prompted. (Default is true).
+     */
+    readonly promptUserForUpgrade?: boolean;
+
+    /**
+     * Indicates whether to open the files (if not already open) and display it to the user.
+     * If not specified, the files will be displayed. (Default is true).
+     */
+    readonly openInTextEditor?: boolean;
+
+    /**
+     * Indicates whether the SARIF viewer should upen when there are no results to display.
+     * If not specificm, the viewer will be displayed. (Default is true).
+     */
+    readonly openViewerOnNoResults?: boolean;
+}
+
+/**
+ * The command the SARIF extension exposes to open SARIF log files.
+ * The expected arguments are of type @see OpenLogFileArguments
+ */
+export const openLogFilesCommand: string = 'extension.sarif.openLogFiles';
+
+/**
+ * The expected arguments for the @see closeLogFileCommand.
+ */
+export interface CloseLogFileArguments {
+    /**
+     * The array of SARIF log files to close.
+     */
+    readonly sarifFiles: vscode.Uri[];
+}
+
+/**
+ * The command the SARIF extension exposes to open SARIF log files.
+ * The expected arguments are of type @see CloseLogFileArguments
+ */
+export const closeLogFilesCommand: string = 'extension.sarif.closeLogFiles';

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -13,13 +13,13 @@ export interface OpenLogArguments {
      * SARIF log schema is needs to be upgraded to the latest one schema version.
      * The default is true.
      */
-    readonly promptUserForUpgrade?: boolean;
+    readonly promptForUpgrade?: boolean;
 
     /**
      * Indicates whether the SARIF viewer should open when there are no results in the logs to display.
      * The default is true.
      */
-    readonly openViewerOnNoResults?: boolean;
+    readonly openViewerWhenNoResults?: boolean;
 }
 
 /**
@@ -27,20 +27,20 @@ export interface OpenLogArguments {
  */
 export interface Api {
     /**
-     * Instructs the SARIF viewer to open logs.
+     * Opens logs .
      * @param logs The logs to open.
      * @param openLogArguments Parameters that control how the logs are opened.
      */
     openLogs(logs: vscode.Uri[], openLogArguments?: OpenLogArguments): Promise<void>;
 
     /**
-     * Instructs the SARIF viewer to close logs.
+     * Closes logs.
      * @param logs The log to close.
      */
     closeLogs(logs: vscode.Uri[]): Promise<void>;
 
     /**
-     * Instructs the SARIF viewer to close all logs.
+     * Closes all logs.
      */
     closeAllLogs(): Promise<void>;
 }

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -4,9 +4,6 @@
 
 import * as vscode from 'vscode';
 
-/**
- * The expected arguments for the @see openLogFileCommand.
- */
 export interface OpenLogFileArguments {
     /**
      * The array of SARIF log files to open. The log file URIs must be of scheme 'file' and be valid SARIF JSON files.
@@ -33,24 +30,22 @@ export interface OpenLogFileArguments {
     readonly openViewerOnNoResults?: boolean;
 }
 
-/**
- * The command the SARIF extension exposes to open SARIF log files.
- * The expected arguments are of type @see OpenLogFileArguments
- */
-export const openLogFilesCommand: string = 'extension.sarif.openLogFiles';
-
-/**
- * The expected arguments for the @see closeLogFileCommand.
- */
-export interface CloseLogFileArguments {
+export interface Api {
     /**
-     * The array of SARIF log files to close.
+     * Instructs the SARIF viewer to open log files.
+     * @param sarifFiles The log files to open..
+     * @param openLogFileArguments Parameters that control how the log files are opened.
      */
-    readonly sarifFiles: vscode.Uri[];
-}
+    openLogFiles(sarifFiles: vscode.Uri[], openLogFileArguments?: OpenLogFileArguments): Promise<void>;
 
-/**
- * The command the SARIF extension exposes to open SARIF log files.
- * The expected arguments are of type @see CloseLogFileArguments
- */
-export const closeLogFilesCommand: string = 'extension.sarif.closeLogFiles';
+    /**
+     * Instructs the SARIF viewer to close log files.
+     * @param sarifFiles The log files to close.
+     */
+    closeLogFiles(sarifFiles: vscode.Uri[]): Promise<void>;
+
+    /**
+     * Instructs the SARIF viewer to closs all log files.
+     */
+    closeAllLogFiles(): Promise<void>;
+}

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -6,11 +6,6 @@ import * as vscode from 'vscode';
 
 export interface OpenLogFileArguments {
     /**
-     * The array of SARIF log files to open. The log file URIs must be of scheme 'file' and be valid SARIF JSON files.
-     */
-    readonly sarifFiles: vscode.Uri[];
-
-    /**
      * Specifies options indicating whether to prompt the user when the
      * SARIF log file shcmea is needs to be ugpraded to the latest one.
      * If not specified, the user will be prompted. (Default is true).

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -16,12 +16,6 @@ export interface OpenLogArguments {
     readonly promptUserForUpgrade?: boolean;
 
     /**
-     * Indicates whether to open SARIF logs inside the VSCode editor.
-     * The default is true.
-     */
-    readonly openInEditor?: boolean;
-
-    /**
      * Indicates whether the SARIF viewer should open when there are no results in the logs to display.
      * The default is true.
      */

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -4,43 +4,49 @@
 
 import * as vscode from 'vscode';
 
-export interface OpenLogFileArguments {
+/**
+ * Options used when the SARIF viewer is opening logs.
+ */
+export interface OpenLogArguments {
     /**
-     * Specifies options indicating whether to prompt the user when the
-     * SARIF log file shcmea is needs to be ugpraded to the latest one.
-     * If not specified, the user will be prompted. (Default is true).
+     * Indicates whether to prompt the user when the
+     * SARIF log schema is needs to be upgraded to the latest one schema version.
+     * The default is true.
      */
     readonly promptUserForUpgrade?: boolean;
 
     /**
-     * Indicates whether to open the files (if not already open) and display it to the user.
-     * If not specified, the files will be displayed. (Default is true).
+     * Indicates whether to open SARIF logs inside the VSCode editor.
+     * The default is true.
      */
-    readonly openInTextEditor?: boolean;
+    readonly openInEditor?: boolean;
 
     /**
-     * Indicates whether the SARIF viewer should upen when there are no results to display.
-     * If not specificm, the viewer will be displayed. (Default is true).
+     * Indicates whether the SARIF viewer should open when there are no results in the logs to display.
+     * The default is true.
      */
     readonly openViewerOnNoResults?: boolean;
 }
 
+/**
+ * API exposed by the SARIF viewer extension.
+ */
 export interface Api {
     /**
-     * Instructs the SARIF viewer to open log files.
-     * @param sarifFiles The log files to open..
-     * @param openLogFileArguments Parameters that control how the log files are opened.
+     * Instructs the SARIF viewer to open logs.
+     * @param logs The logs to open.
+     * @param openLogArguments Parameters that control how the logs are opened.
      */
-    openLogFiles(sarifFiles: vscode.Uri[], openLogFileArguments?: OpenLogFileArguments): Promise<void>;
+    openLogs(logs: vscode.Uri[], openLogArguments?: OpenLogArguments): Promise<void>;
 
     /**
-     * Instructs the SARIF viewer to close log files.
-     * @param sarifFiles The log files to close.
+     * Instructs the SARIF viewer to close logs.
+     * @param logs The log to close.
      */
-    closeLogFiles(sarifFiles: vscode.Uri[]): Promise<void>;
+    closeLogs(logs: vscode.Uri[]): Promise<void>;
 
     /**
-     * Instructs the SARIF viewer to closs all log files.
+     * Instructs the SARIF viewer to close all logs.
      */
-    closeAllLogFiles(): Promise<void>;
+    closeAllLogs(): Promise<void>;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -203,6 +203,6 @@ export async function openSarifFile(sarifFile: vscode.Uri, logReader: LogReader,
  */
 function onDocumentClosed(doc: vscode.TextDocument, diagnosticCollection: SVDiagnosticCollection): void {
     if (doc.uri.isSarifFile()) {
-        diagnosticCollection.removeRuns(doc.uri);
+        diagnosticCollection.removeRuns([doc.uri]);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,13 +23,14 @@ import * as sarifViewrApi from "./api/sarifViewerApi";
 // This is equiavelnt to "including" the generated javscript to get the code to run that sets the prototypes for the extension methods.
 // If you don't do this... you crash using the extension methods.
 import './utilities/stringUtilities';
+import { ApiImpl } from './utilities/apiImpl';
 
 /**
  * This method is called when the extension is activated.
  * Creates the explorer, reader, provider
  * Process any open SARIF Files
  */
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(context: vscode.ExtensionContext): sarifViewrApi.Api {
     Utilities.initialize(context);
     FileConverter.initialize(context);
 
@@ -65,9 +66,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // We do not need to block extension startup for reading any open documents.
     void readOpenedDocuments(logReader, diagnosticCollection);
 
-    context.subscriptions.push(vscode.commands.registerCommand(sarifViewrApi.openLogFilesCommand, (args) => onOpenLogFilesCommand(logReader, diagnosticCollection, args)));
-
-    context.subscriptions.push(vscode.commands.registerCommand(sarifViewrApi.closeLogFilesCommand, (args) => onCloseLogFilesCommand(diagnosticCollection, args)));
+    return new ApiImpl(logReader, diagnosticCollection);
 }
 
 /**
@@ -140,7 +139,7 @@ async function openSarifFileIfNotOpen(sarifFile: vscode.Uri): Promise<void> {
  * @param diagnosticCollection The diagnostic collection to add the results too.
  * @param options Options controlling the upgrade prompt if a SARIF file is at an earlier schema version.
  */
-async function openSarifFile(sarifFile: vscode.Uri, logReader: LogReader, diagnosticCollection: SVDiagnosticCollection, options: OpenSarifFileOptions): Promise<void> {
+export async function openSarifFile(sarifFile: vscode.Uri, logReader: LogReader, diagnosticCollection: SVDiagnosticCollection, options: OpenSarifFileOptions): Promise<void> {
     if (!sarifFile.isSarifFile()) {
         return;
     }
@@ -205,35 +204,5 @@ async function openSarifFile(sarifFile: vscode.Uri, logReader: LogReader, diagno
 function onDocumentClosed(doc: vscode.TextDocument, diagnosticCollection: SVDiagnosticCollection): void {
     if (doc.uri.isSarifFile()) {
         diagnosticCollection.removeRuns(doc.uri);
-    }
-}
-
-/**
- * Responds to the @see sarifViewerApi.openLogFilesCommand
- */
-async function onOpenLogFilesCommand(logReader: LogReader, diagnosticCollection: SVDiagnosticCollection, openLogFileArguments?: sarifViewrApi.OpenLogFileArguments): Promise<void> {
-    if (!openLogFileArguments) {
-        return;
-    }
-
-    for (const sarifUri of openLogFileArguments.sarifFiles) {
-        await openSarifFile(sarifUri, logReader, diagnosticCollection, {
-            closeOriginalFileOnUpgrade: true,
-            openInTextEditor: openLogFileArguments.openInTextEditor === undefined ? true : openLogFileArguments.openInTextEditor,
-            promptUserForUpgrade: openLogFileArguments.promptUserForUpgrade === undefined ? true : openLogFileArguments.promptUserForUpgrade
-        });
-    }
-}
-
-/**
- * Responds to the @see sarifViewerApi.closeLogFilesCommand
- */
-async function onCloseLogFilesCommand(diagnosticCollection: SVDiagnosticCollection, closeLogFileArguments?: sarifViewrApi.CloseLogFileArguments): Promise<void> {
-    if (!closeLogFileArguments) {
-        return;
-    }
-
-    for (const sarifUri of closeLogFileArguments.sarifFiles) {
-        diagnosticCollection.removeRuns(sarifUri);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,9 +18,9 @@ import { Utilities } from "./utilities";
 import { ResultsListController } from "./resultsListController";
 import { FileMapper } from "./fileMapper";
 import { SVDiagnosticCollection } from "./svDiagnosticCollection";
-import * as sarifViewrApi from "./api/sarifViewerApi";
+import { Api } from "./api/sarifViewerApi";
 
-// This is equiavelnt to "including" the generated javscript to get the code to run that sets the prototypes for the extension methods.
+// This is equivalent to "including" the generated javascript to get the code to run that sets the prototypes for the extension methods.
 // If you don't do this... you crash using the extension methods.
 import './utilities/stringUtilities';
 import { ApiImpl } from './utilities/apiImpl';
@@ -30,7 +30,7 @@ import { ApiImpl } from './utilities/apiImpl';
  * Creates the explorer, reader, provider
  * Process any open SARIF Files
  */
-export function activate(context: vscode.ExtensionContext): sarifViewrApi.Api {
+export function activate(context: vscode.ExtensionContext): Api {
     Utilities.initialize(context);
     FileConverter.initialize(context);
 
@@ -157,7 +157,7 @@ export async function openSarifFile(sarifFile: vscode.Uri, logReader: LogReader,
     if (logReaderResult.upgradeCheckInformation.upgradedNeeded === 'Schema Undefined') {
         if (!logReaderResult.upgradeCheckInformation.parsedSchemaVersion) {
             await vscode.window.showErrorMessage(
-                localize('logReader.schemaNotDefined', "Sarif Viewer: Cannot display results for '{0}' because the shema was not defined.",
+                localize('logReader.schemaNotDefined', "Sarif Viewer: Cannot display results for '{0}' because the schema was not defined.",
                     path.basename(sarifFile.fsPath)));
         }
         return;
@@ -165,7 +165,7 @@ export async function openSarifFile(sarifFile: vscode.Uri, logReader: LogReader,
 
     if (logReaderResult.upgradeCheckInformation.upgradedNeeded === 'Schema Unknown' && logReaderResult.sarifLog) {
         await vscode.window.showErrorMessage(localize(
-            'converterTool.UpgraderErrorMessage',
+            'converterTool.UpgradedErrorMessage',
             "Sarif version '{0}'(schema '{1}') is not yet supported by the Viewer. Make sure you have the latest extension version and check https://github.com/Microsoft/sarif-vscode-extension for future support.",
             logReaderResult.sarifLog.version, logReaderResult.sarifLog.$schema));
         return;
@@ -198,7 +198,7 @@ export async function openSarifFile(sarifFile: vscode.Uri, logReader: LogReader,
 
 /**
  * When a sarif document closes we need to clear all of the list of issues and reread the open sarif docs
- * Can't selectivly remove issues becuase the issues don't have a link back to the sarif file it came from
+ * Can't selectively remove issues because the issues don't have a link back to the sarif file it came from
  * @param doc document that was closed
  */
 function onDocumentClosed(doc: vscode.TextDocument, diagnosticCollection: SVDiagnosticCollection): void {

--- a/src/factories/locationFactory.ts
+++ b/src/factories/locationFactory.ts
@@ -81,7 +81,7 @@ export namespace LocationFactory {
             toJSON: Utilities.LocationToJson,
             mapLocationToLocalPath: FileMapper.mapLocationToLocalPath,
             get locationMapped(): Event<Location> {
-                // See this git-hub issue for disucssion of this rule => https://github.com/palantir/tslint/issues/1544
+                // See this git-hub issue for discussion of this rule => https://github.com/palantir/tslint/issues/1544
                 // tslint:disable-next-line: no-invalid-this
                 return FileMapper.uriMappedForLocation.bind(this)();
             }
@@ -131,7 +131,7 @@ export namespace LocationFactory {
             toJSON: Utilities.LocationToJson,
             mapLocationToLocalPath: FileMapper.mapLocationToLocalPath,
             get locationMapped(): Event<Location> {
-                // See this git-hub issue for disucssion of this rule => https://github.com/palantir/tslint/issues/1544
+                // See this git-hub issue for discussion of this rule => https://github.com/palantir/tslint/issues/1544
                 // tslint:disable-next-line: no-invalid-this
                 return FileMapper.uriMappedForLocation.bind(this)();
             }

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -90,11 +90,11 @@ export class FileConverter {
         };
 
         const quickPickItems: ToolQuickPickItem[] = [];
-        for (const tooleNameKey of Object.keys(fileConverterTools)) {
+        for (const toolNameKey of Object.keys(fileConverterTools)) {
             quickPickItems.push({
-                label: fileConverterTools[tooleNameKey].name,
-                extensions: fileConverterTools[tooleNameKey].extensions,
-                toolKey: tooleNameKey
+                label: fileConverterTools[toolNameKey].name,
+                extensions: fileConverterTools[toolNameKey].extensions,
+                toolKey: toolNameKey
             });
         }
 
@@ -135,9 +135,9 @@ export class FileConverter {
         const parsedVersion: SarifVersion = FileConverter.parseVersion(sarifLog.version);
 
         // If the SARIF log has the same version as the multi-tool version, then there is nothing to convert.
-        // The version here is not the version off the shchema string, it is just the version
+        // The version here is not the version off the schema string, it is just the version
         // property in the SARIF JSON.
-        // (Assuming of course that the multi-tool is kept in sync with the SARF npm package this extension relies on).
+        // (Assuming of course that the multi-tool is kept in sync with the SARIF npm package this extension relies on).
         // We need to open an issue on this as the @types/sarif version and the multi-tool version can stray apart because
         // the multi-tool code package has no exports to say what version of the schema it is on.
         if (parsedVersion.original === mTCurVersion.original) {
@@ -285,7 +285,7 @@ export class FileConverter {
         const errorData: string[] = [];
         const converted: boolean = await new Promise<boolean>((resolve) => {
             // If you are tempted to put quotes around these strings, please don't as "spawn" does that internally.
-            // Something to consider is adding an option to the SARIF viewr so the path to the multi-tool
+            // Something to consider is adding an option to the SARIF viewer so the path to the multi-tool
             // can be over-ridden for testing.
             const proc: ChildProcess = spawn(FileConverter.multiToolPath, ['transform', sarifFile.fsPath, '-o', fileOutputPath, '-p', '-f']);
 

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -169,7 +169,7 @@ export class FileConverter {
         // {
         //   "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
         //
-        const parsedSchemaVersion: SarifVersion | undefined = sarifLog.$schema !== undefined ? FileConverter.parseSchema(schemaUri) : undefined;
+        const parsedSchemaVersion: SarifVersion | undefined = FileConverter.parseSchema(schemaUri);
         if (!parsedSchemaVersion) {
             return {
                 upgradedNeeded: 'Could Not Parse Schema',

--- a/src/fileMapper.ts
+++ b/src/fileMapper.ts
@@ -289,7 +289,7 @@ export class FileMapper implements Disposable {
     }
 
     /**
-     * Shows the Inputbox with message for getting the user to select the mapping
+     * Shows the input box with message for getting the user to select the mapping
      * @param uri uri of the file that needs to be mapped
      */
     private async openRemappingInputDialog(uri: Uri): Promise<string | undefined> {

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -20,7 +20,7 @@ import { ProgressHelper } from "./progressHelper";
 import { CodeFlowFactory } from "./factories/codeFlowFactory";
 
 /**
- * Optinos used when readining\import SARIF files.
+ * Options used when reading\import SARIF files.
  */
 export interface ReadOptions {
     /**
@@ -73,7 +73,7 @@ export class LogReader implements Disposable {
 
     /**
      * Contains a map between a parsed SARIF file (the key) to a JsonMapping object which contains
-     * the result of the JSON parsing. This contains the actual SAIRF content and the "pointers" (which are like xpath's for XML)
+     * the result of the JSON parsing. This contains the actual SARIF content and the "pointers" (which are like xpath's for XML)
      * to elements found in the JSON.
      */
     private readonly sarifJSONMapping: Map<string, JsonMapping> = new Map<string, JsonMapping>();
@@ -98,7 +98,7 @@ export class LogReader implements Disposable {
         const pOptions: ProgressOptions = {
             cancellable: false,
             location: ProgressLocation.Notification,
-            title: localize('logReader.proecssingTitle', "Processing {0}", path.basename(sarifFile.fsPath)),
+            title: localize('logReader.processingTitle', "Processing {0}", path.basename(sarifFile.fsPath)),
         };
 
         let upgradeCheckInformation: UpgradeCheckInformation = {
@@ -107,7 +107,7 @@ export class LogReader implements Disposable {
 
         const readResults: ParseResults[] = [];
 
-        await window.withProgress(pOptions, async (progress: Progress<{ message?: string; increment?: number }>, cancleToken): Promise<void> => {
+        await window.withProgress(pOptions, async (progress: Progress<{ message?: string; increment?: number }>, cancelToken): Promise<void> => {
             ProgressHelper.Instance.Progress = progress;
             let runInfo: RunInfo;
 

--- a/src/svDiagnosticCollection.ts
+++ b/src/svDiagnosticCollection.ts
@@ -241,6 +241,16 @@ export class SVDiagnosticCollection implements Disposable {
     }
 
     /**
+     * Removes all information from the diagnostic collection.
+     */
+    public removeAllRuns(): void {
+        this.runInfoCollection.length = 0;
+        this.mappedIssuesCollection.clear();
+        this.unmappedIssuesCollection.clear();
+        this.syncIssuesWithDiagnosticCollection();
+    }
+
+    /**
      * Sets the active diagnostic in the collection and fires the active diagnostic changed event.
      * @param newDiagnostic The new diagnostic to set.
      */

--- a/src/svDiagnosticCollection.ts
+++ b/src/svDiagnosticCollection.ts
@@ -222,21 +222,24 @@ export class SVDiagnosticCollection implements Disposable {
      * Iterates through the issue collections and removes any results that originated from the file
      * @param sarifFile Path (including file) of the file that has the runs to be removed
      */
-    public removeRuns(sarifFile: Uri): void {
-        if (!sarifFile.isSarifFile()) {
-            return;
-        }
-
-        const runsToRemove: number[] = [];
-        for (let i: number = this.runInfoCollection.length - 1; i >= 0; i--) {
-            if (this.runInfoCollection[i].sarifFileFullPath === sarifFile.fsPath) {
-                runsToRemove.push(this.runInfoCollection[i].id);
-                this.runInfoCollection.splice(i, 1);
+    public removeRuns(sarifFiles: Uri[]): void {
+        for (const sarifFile of sarifFiles) {
+            if (!sarifFile.isSarifFile()) {
+                return;
             }
+
+            const runsToRemove: number[] = [];
+            for (let i: number = this.runInfoCollection.length - 1; i >= 0; i--) {
+                if (this.runInfoCollection[i].sarifFileFullPath === sarifFile.fsPath) {
+                    runsToRemove.push(this.runInfoCollection[i].id);
+                    this.runInfoCollection.splice(i, 1);
+                }
+            }
+
+            this.removeResults(runsToRemove, this.mappedIssuesCollection);
+            this.removeResults(runsToRemove, this.unmappedIssuesCollection);
         }
 
-        this.removeResults(runsToRemove, this.mappedIssuesCollection);
-        this.removeResults(runsToRemove, this.unmappedIssuesCollection);
         this.syncIssuesWithDiagnosticCollection();
     }
 
@@ -244,10 +247,7 @@ export class SVDiagnosticCollection implements Disposable {
      * Removes all information from the diagnostic collection.
      */
     public removeAllRuns(): void {
-        this.runInfoCollection.length = 0;
-        this.mappedIssuesCollection.clear();
-        this.unmappedIssuesCollection.clear();
-        this.syncIssuesWithDiagnosticCollection();
+        this.removeRuns(this.runInfoCollection.map((runInfo) => Uri.file(runInfo.sarifFileFullPath)));
     }
 
     /**

--- a/src/svDiagnosticCollection.ts
+++ b/src/svDiagnosticCollection.ts
@@ -17,7 +17,7 @@ export interface SVDiagnosticsChangedEvent {
 }
 
 /**
- * Manager for the Diagnostic Collection contianing the sarif result diagnostics
+ * Manager for the Diagnostic Collection containing the sarif result diagnostics
  * Allows us to control which diagnostics we send to the Problems panel, so we can show a custom message on max entries
  * And lets us easily try to map those that weren't mapped previously
  */
@@ -35,7 +35,7 @@ export class SVDiagnosticCollection implements Disposable {
     private readonly diagnosticCollection: DiagnosticCollection = languages.createDiagnosticCollection(SVDiagnosticCollection.name);
 
     /**
-     * The 'mapped' collection cotnains diagnostics that have had their file-paths mapped to a local path.
+     * The 'mapped' collection contains diagnostics that have had their file-paths mapped to a local path.
      * The "key" is the Uri to the mapped file (i.e. file://a/b/c/foo.cpp)
      */
     private readonly mappedIssuesCollection: Map<string, SarifViewerVsCodeDiagnostic[]> = new Map<string, SarifViewerVsCodeDiagnostic[]>();
@@ -219,7 +219,7 @@ export class SVDiagnosticCollection implements Disposable {
     }
 
     /**
-     * Itterates through the issue collections and removes any results that originated from the file
+     * Iterates through the issue collections and removes any results that originated from the file
      * @param sarifFile Path (including file) of the file that has the runs to be removed
      */
     public removeRuns(sarifFile: Uri): void {
@@ -418,11 +418,11 @@ export class SVDiagnosticCollection implements Disposable {
      */
     private onDidChangeTextEditorSelection(textEditorSelectionChanged: TextEditorSelectionChangeEvent): void {
         // If the selection changed to a text editor that isn't visible, then we will ignore it.
-        if (!window.visibleTextEditors.find((visibleTextEdtior) => visibleTextEdtior === textEditorSelectionChanged.textEditor)) {
+        if (!window.visibleTextEditors.find((visibleTextEditor) => visibleTextEditor === textEditorSelectionChanged.textEditor)) {
             return;
         }
 
-        // If there isn't a valid selction, then we will also ignore it.
+        // If there isn't a valid selection, then we will also ignore it.
         if (textEditorSelectionChanged.selections.length !== 1) {
             return;
         }

--- a/src/test/locationFactory.test.ts
+++ b/src/test/locationFactory.test.ts
@@ -10,7 +10,7 @@ import { LocationFactory } from "../factories/locationFactory";
 
 suite("parseRange", () => {
     test("Undefined range", async () => {
-        const region: sarif.Region | undefined = undefined;
+        const region: sarif.Region = {};
         const expected: Range = new Range(0, 0, 0, 1);
         // @ts-ignore parseRange is a private static method on LocationFactory
         const result: { range: Range; endOfLine: boolean } = LocationFactory.parseRange(region);

--- a/src/utilities/apiImpl.ts
+++ b/src/utilities/apiImpl.ts
@@ -38,7 +38,7 @@ export class ApiImpl implements sarifApi.Api {
             this.diagnosticCollection.removeRuns(sarifUri);
         }
 
-        return Promise.resolve();
+        return;
     }
 
     /**
@@ -46,6 +46,7 @@ export class ApiImpl implements sarifApi.Api {
      */
     public async closeAllLogs(): Promise<void> {
         this.diagnosticCollection.removeAllRuns();
-        return Promise.resolve();
+
+        return;
     }
 }

--- a/src/utilities/apiImpl.ts
+++ b/src/utilities/apiImpl.ts
@@ -20,12 +20,12 @@ export class ApiImpl implements sarifApi.Api {
     /**
      * @inheritdoc
      */
-    public async openLogFiles(sarifFiles: vscode.Uri[], openLogFileArguments?: sarifApi.OpenLogFileArguments): Promise<void> {
+    public async openLogs(sarifFiles: vscode.Uri[], openLogFileArguments?: sarifApi.OpenLogArguments): Promise<void> {
         for (const sarifUri of sarifFiles) {
             await openSarifFile(sarifUri, this.logReader, this.diagnosticCollection, {
                 closeOriginalFileOnUpgrade: true,
-                openInTextEditor: openLogFileArguments?.openInTextEditor === undefined ? true : openLogFileArguments.openInTextEditor,
-                promptUserForUpgrade: openLogFileArguments?.promptUserForUpgrade === undefined ? true : openLogFileArguments.promptUserForUpgrade
+                openInTextEditor: openLogFileArguments?.openInEditor ?? true,
+                promptUserForUpgrade: openLogFileArguments?.promptUserForUpgrade ?? true
             });
         }
     }
@@ -33,7 +33,7 @@ export class ApiImpl implements sarifApi.Api {
     /**
      * @inheritdoc
      */
-    public async closeLogFiles(sarifFiles: vscode.Uri[]): Promise<void> {
+    public async closeLogs(sarifFiles: vscode.Uri[]): Promise<void> {
         for (const sarifUri of sarifFiles) {
             this.diagnosticCollection.removeRuns(sarifUri);
         }
@@ -44,7 +44,7 @@ export class ApiImpl implements sarifApi.Api {
     /**
      * @inheritdoc
      */
-    public async closeAllLogFiles(): Promise<void> {
+    public async closeAllLogs(): Promise<void> {
         this.diagnosticCollection.removeAllRuns();
         return Promise.resolve();
     }

--- a/src/utilities/apiImpl.ts
+++ b/src/utilities/apiImpl.ts
@@ -24,7 +24,7 @@ export class ApiImpl implements sarifApi.Api {
         for (const sarifUri of sarifFiles) {
             await openSarifFile(sarifUri, this.logReader, this.diagnosticCollection, {
                 closeOriginalFileOnUpgrade: true,
-                openInTextEditor: openLogFileArguments?.openInEditor ?? true,
+                openInTextEditor: false,
                 promptUserForUpgrade: openLogFileArguments?.promptUserForUpgrade ?? true
             });
         }

--- a/src/utilities/apiImpl.ts
+++ b/src/utilities/apiImpl.ts
@@ -20,12 +20,12 @@ export class ApiImpl implements sarifApi.Api {
     /**
      * @inheritdoc
      */
-    public async openLogs(sarifFiles: vscode.Uri[], openLogFileArguments?: sarifApi.OpenLogArguments): Promise<void> {
-        for (const sarifUri of sarifFiles) {
-            await openSarifFile(sarifUri, this.logReader, this.diagnosticCollection, {
+    public async openLogs(logs: vscode.Uri[], openLogFileArguments?: sarifApi.OpenLogArguments): Promise<void> {
+        for (const log of logs) {
+            await openSarifFile(log, this.logReader, this.diagnosticCollection, {
                 closeOriginalFileOnUpgrade: true,
                 openInTextEditor: false,
-                promptUserForUpgrade: openLogFileArguments?.promptUserForUpgrade ?? true
+                promptUserForUpgrade: openLogFileArguments?.promptForUpgrade ?? true
             });
         }
     }
@@ -33,9 +33,9 @@ export class ApiImpl implements sarifApi.Api {
     /**
      * @inheritdoc
      */
-    public async closeLogs(sarifFiles: vscode.Uri[]): Promise<void> {
-        for (const sarifUri of sarifFiles) {
-            this.diagnosticCollection.removeRuns(sarifUri);
+    public async closeLogs(logs: vscode.Uri[]): Promise<void> {
+        for (const log of logs) {
+            this.diagnosticCollection.removeRuns(log);
         }
 
         return;

--- a/src/utilities/apiImpl.ts
+++ b/src/utilities/apiImpl.ts
@@ -35,7 +35,7 @@ export class ApiImpl implements sarifApi.Api {
      */
     public async closeLogs(logs: vscode.Uri[]): Promise<void> {
         for (const log of logs) {
-            this.diagnosticCollection.removeRuns(log);
+            this.diagnosticCollection.removeRuns([log]);
         }
 
         return;

--- a/src/utilities/apiImpl.ts
+++ b/src/utilities/apiImpl.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ */
+
+import * as sarifApi from "./../api/sarifViewerApi";
+import * as vscode from "vscode";
+import { LogReader } from "../logReader";
+import { SVDiagnosticCollection } from "../svDiagnosticCollection";
+import { openSarifFile } from "../extension";
+
+export class ApiImpl implements sarifApi.Api {
+    /**
+     * Constructs an instance of the API given out by the extension.
+     * @param logReader An instance of the log reader to use for parsing log files.
+     * @param diagnosticCollection The diagnostic collection that holds the results.
+     */
+    public constructor(private readonly logReader: LogReader, private readonly diagnosticCollection: SVDiagnosticCollection) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public async openLogFiles(sarifFiles: vscode.Uri[], openLogFileArguments?: sarifApi.OpenLogFileArguments): Promise<void> {
+        for (const sarifUri of sarifFiles) {
+            await openSarifFile(sarifUri, this.logReader, this.diagnosticCollection, {
+                closeOriginalFileOnUpgrade: true,
+                openInTextEditor: openLogFileArguments?.openInTextEditor === undefined ? true : openLogFileArguments.openInTextEditor,
+                promptUserForUpgrade: openLogFileArguments?.promptUserForUpgrade === undefined ? true : openLogFileArguments.promptUserForUpgrade
+            });
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public async closeLogFiles(sarifFiles: vscode.Uri[]): Promise<void> {
+        for (const sarifUri of sarifFiles) {
+            this.diagnosticCollection.removeRuns(sarifUri);
+        }
+
+        return Promise.resolve();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public async closeAllLogFiles(): Promise<void> {
+        this.diagnosticCollection.removeAllRuns();
+        return Promise.resolve();
+    }
+}


### PR DESCRIPTION
This change exposes an API for other extension to pass "SARIF" files to the extension to process and load into the viewer. It address isssue #244 and issues #229 .

The API should eventually be turned into a "typings" NODE package and published so it can be downloaded through NPM as "microsoft/sarf-viewer-api".

I want to hold off on that until we proove out not only the API with our dependent extension owners, but also verify that we like the names, function signatures, etc.

This has been verified to function end to end with another extension developed at Microsoft.