### PR TITLE
File mapping strikes again.. (no active result set when file mapping hasn't been completed)

### DIFF
--- a/src/codeFlowDecorations.ts
+++ b/src/codeFlowDecorations.ts
@@ -459,7 +459,11 @@ export class CodeFlowDecorations implements Disposable {
             case MessageType.SourceLinkClicked:
                 const locData: LocationData = JSON.parse(webViewMessage.data);
                 const location: Location = {
-                    mappedToLocalPath: false,
+                    // We don't know from the location data coming back from the web-view
+                    // is really "mapped" or not, so we assume it isn't. This works out for
+                    // us because if it is, no user prompt will occur. If it isn't
+                    // then we do want the prompt since the user just clicked on a link!
+                    mappedToLocalPath: false, 
                     range: new Range(parseInt(locData.sLine, 10), parseInt(locData.sCol, 10),
                         parseInt(locData.eLine, 10), parseInt(locData.eCol, 10)),
                     uri: Uri.parse(locData.file),

--- a/src/codeFlowDecorations.ts
+++ b/src/codeFlowDecorations.ts
@@ -463,7 +463,7 @@ export class CodeFlowDecorations implements Disposable {
                     // is really "mapped" or not, so we assume it isn't. This works out for
                     // us because if it is, no user prompt will occur. If it isn't
                     // then we do want the prompt since the user just clicked on a link!
-                    mappedToLocalPath: false, 
+                    mappedToLocalPath: false,
                     range: new Range(parseInt(locData.sLine, 10), parseInt(locData.sCol, 10),
                         parseInt(locData.eLine, 10), parseInt(locData.eCol, 10)),
                     uri: Uri.parse(locData.file),

--- a/src/codeFlowDecorations.ts
+++ b/src/codeFlowDecorations.ts
@@ -8,7 +8,8 @@ import * as sarif from "sarif";
 
 import {
     commands, DecorationInstanceRenderOptions, DecorationOptions, DecorationRangeBehavior, DiagnosticSeverity, OverviewRulerLane,
-    Position, Range, TextEditor, TextEditorDecorationType, TextEditorRevealType, Uri, ViewColumn, window, workspace, TextDocument, Disposable, Event
+    Position, Range, TextEditor, TextEditorDecorationType, TextEditorRevealType, Uri, ViewColumn, window, workspace, TextDocument, Disposable, Event,
+    Selection
 } from "vscode";
 import { CodeFlowStep, CodeFlowStepId, Location, CodeFlow, WebviewMessage, LocationData } from "./common/interfaces";
 import { ExplorerController } from "./explorerController";
@@ -291,6 +292,7 @@ export class CodeFlowDecorations implements Disposable {
         const textDocument: TextDocument = await workspace.openTextDocument(mappedUri);
         const textEditor: TextEditor = await window.showTextDocument(textDocument, ViewColumn.One, true);
         textEditor.setDecorations(CodeFlowDecorations.SelectionDecorationType, [{ range: locRange }]);
+        textEditor.selection = new Selection(locRange.start, locRange.end);
         textEditor.revealRange(locRange, TextEditorRevealType.InCenterIfOutsideViewport);
     }
 
@@ -457,14 +459,14 @@ export class CodeFlowDecorations implements Disposable {
             case MessageType.SourceLinkClicked:
                 const locData: LocationData = JSON.parse(webViewMessage.data);
                 const location: Location = {
-                    mappedToLocalPath: true,
+                    mappedToLocalPath: false,
                     range: new Range(parseInt(locData.sLine, 10), parseInt(locData.sCol, 10),
                         parseInt(locData.eLine, 10), parseInt(locData.eCol, 10)),
                     uri: Uri.parse(locData.file),
                     toJSON:  Utilities.LocationToJson,
                     mapLocationToLocalPath: FileMapper.mapLocationToLocalPath,
                     get locationMapped(): Event<Location> {
-                        // See this git-hub issue for disucssion of this rule => https://github.com/palantir/tslint/issues/1544
+                        // See this git-hub issue for discussion of this rule => https://github.com/palantir/tslint/issues/1544
                         // tslint:disable-next-line: no-invalid-this
                         return FileMapper.uriMappedForLocation.bind(this)();
                     }

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -88,6 +88,12 @@ export interface Location {
      * Event that is fired when the location is mapped..
      */
     locationMapped: Event<Location>;
+
+    /**
+     * When a location is converted to "JSON", we covert the URI to a string and store it here
+     * so the web-view can use it since it does not have easy access to vscode's node APIs.
+     */
+    readonly uriAsString?: string;
 }
 
 

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -90,7 +90,7 @@ export interface Location {
     locationMapped: Event<Location>;
 
     /**
-     * When a location is converted to "JSON", we covert the URI to a string and store it here
+     * When a location is converted to "JSON", we convert the URI to a string and store it here
      * so the web-view can use it since it does not have easy access to vscode's node APIs.
      */
     readonly uriAsString?: string;

--- a/src/explorer/resultsList.ts
+++ b/src/explorer/resultsList.ts
@@ -671,11 +671,11 @@ export class ResultsList {
         const showColButton: HTMLElement | null = document.getElementById("resultslistshowcol");
 
         if (!groupByButton) {
-            throw new Error("Epxected to find group by button.");
+            throw new Error("Expected to find group by button.");
         }
 
         if (!showColButton) {
-            throw new Error("Epxected to find show column button.");
+            throw new Error("Expected to find show column button.");
         }
 
         if (groupByButton.children.length === 1) {

--- a/src/explorer/webview.ts
+++ b/src/explorer/webview.ts
@@ -740,7 +740,7 @@ export class ExplorerWebview {
             for (const frame of stack.frames) {
                 const fLocation: Location = frame.location;
                 let file: string | undefined;
-                if (fLocation.uriAsString) {
+                if (fLocation.uriAsString !== undefined) {
                     file = fLocation.uriAsString;
                 }
 

--- a/src/explorer/webview.ts
+++ b/src/explorer/webview.ts
@@ -346,9 +346,8 @@ export class ExplorerWebview {
             if (options.tooltip === undefined) {
                 if (options.message !== undefined) {
                     options.tooltip = options.message;
-                } else if (options.location.uri !== undefined) {
-                    // @ts-ignore external exist on the webview side
-                    options.tooltip = options.location.uri.external.replace("%3A", ":");
+                } else if (options.location.uriAsString !== undefined) {
+                    options.tooltip = options.location.uriAsString;
                 }
             }
         }
@@ -741,9 +740,8 @@ export class ExplorerWebview {
             for (const frame of stack.frames) {
                 const fLocation: Location = frame.location;
                 let file: string | undefined;
-                if (fLocation.uri) {
-                    // @ts-ignore external exist on the webview side
-                    file = fLocation.uri.external.replace("%3A", ":");
+                if (fLocation.uriAsString) {
+                    file = fLocation.uriAsString;
                 }
 
                 const fRow: HTMLTableRowElement = this.createElement("tr", {
@@ -843,18 +841,16 @@ export class ExplorerWebview {
      */
     private createSourceLink(location: Location, linkText: string): HTMLAnchorElement | undefined {
         let sourceLink: HTMLAnchorElement | undefined;
-        if (location.uri && location.range) {
-            // @ts-ignore external exist on the webview side
-            const file: string = location.uri.external.replace("%3A", ":");
+        if (location.uriAsString && location.range) {
             sourceLink = this.createElement("a", {
                 attributes: {
                     "data-eCol": location.range.end.character.toString(),
                     "data-eLine": location.range.end.line.toString(),
-                    "data-file": file,
+                    "data-file": location.uriAsString,
                     "data-sCol": location.range.start.character.toString(),
                     "data-sLine": location.range.start.line.toString(),
                     "href": "#0",
-                }, className: "sourcelink", text: linkText, tooltip: file,
+                }, className: "sourcelink", text: linkText, tooltip: location.uriAsString,
             }) as HTMLAnchorElement;
 
             sourceLink.addEventListener("click", this.onSourceLinkClicked.bind(this));

--- a/src/explorer/webview.ts
+++ b/src/explorer/webview.ts
@@ -841,7 +841,7 @@ export class ExplorerWebview {
      */
     private createSourceLink(location: Location, linkText: string): HTMLAnchorElement | undefined {
         let sourceLink: HTMLAnchorElement | undefined;
-        if (location.uriAsString && location.range) {
+        if (location.uriAsString !== undefined && location.range) {
             sourceLink = this.createElement("a", {
                 attributes: {
                     "data-eCol": location.range.end.character.toString(),

--- a/src/resultsListController.ts
+++ b/src/resultsListController.ts
@@ -156,13 +156,13 @@ export class ResultsListController implements Disposable {
                     break;
                 }
 
-                if (!diagnostic.resultInfo.assignedLocation) {
-                    return;
-                }
+                // Set the active diagnostic (which causes a cascade of setting up the result info
+                // pane due to the events this fires)
+                this.diagnosticCollection.activeDiagnostic = diagnostic;
 
                 // Attempt to map the result if it hasn't been mapped
-                const diagLocation: Location = diagnostic.resultInfo.assignedLocation;
-                if (!diagLocation.uri) {
+                const diagLocation: Location | undefined = diagnostic.resultInfo.assignedLocation;
+                if (!diagLocation?.uri) {
                     return;
                 }
 

--- a/src/svDiagnosticCollection.ts
+++ b/src/svDiagnosticCollection.ts
@@ -254,11 +254,18 @@ export class SVDiagnosticCollection implements Disposable {
      * Sets the active diagnostic in the collection and fires the active diagnostic changed event.
      * @param newDiagnostic The new diagnostic to set.
      */
-    private set activeDiagnostic(newDiagnostic: SarifViewerVsCodeDiagnostic | undefined) {
+    public set activeDiagnostic(newDiagnostic: SarifViewerVsCodeDiagnostic | undefined) {
         if (this.activeSVDiagnostic !== newDiagnostic) {
             this.activeSVDiagnostic = newDiagnostic;
             this.onDidChangeActiveDiagnosticEventEmitter.fire(newDiagnostic);
         }
+    }
+
+    /**
+     * Returns the active diagnostic (if any).
+     */
+    public get activeDiagnostic(): SarifViewerVsCodeDiagnostic | undefined {
+        return this.activeSVDiagnostic;
     }
 
     /**

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -506,6 +506,7 @@ export class Utilities {
     public static LocationToJson(this: Location, key: any, value: any): any {
         return {
             ...this,
+            uriAsString: this?.uri?.toString(/*skipEncoding*/ true),
             range: {
                 ...this.range,
                 start: this.range.start,


### PR DESCRIPTION
This adress issues #256 and #255 
There were a couple of hidden things going on.

When a result was clicked in the explorer view, the "result list controller" receives a message. The result list controller needed to set what the rest of the extension believes is the "active diagnostic" (selected result) through the rest of the system. It was not doing that at all (something I like regressed).

After doing that, I ran into the fact that the source links did not work clicked on. Fixed that too.

There were 2 issues there, the first was that there was a Tslint (ignore) in the code, which, well, shouldn't have been ignored as it was causing an exception since "external" really was undefined. The second was that when the source link was clicked on, we assumed that it had already been "mapped" by the file-mapper, which was the wrong assumption.