### PR TITLE
Fix issue when using file picker to map files

### DIFF
--- a/src/fileMapper.ts
+++ b/src/fileMapper.ts
@@ -206,7 +206,7 @@ export class FileMapper implements Disposable {
             }];
 
             disposables.push(input.onDidAccept(() => {
-                if (resolvedString) {∏
+                if (resolvedString) {
                     input.hide();
                 }
             }));


### PR DESCRIPTION
This address issues #260. The fix was simple, when we returned from the file picker dialog, we set the "value" property on VSCode's InputBox object thinking it would fire an event that the value changed, which, it does not. So, picking a file alone would not complete the mapping.

The change is to move the logic that handles the value changing into a local function that can be used both for handling the input box and the return from the file picker.

Verified on both Mac and PC that picking a file works as well as typing the path.