### PR TITLE
Add signing config file to allow embedding x509 cerificate

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,5 +11,5 @@ sariftypesgenerator/**
 samples/**
 workspace.code-workspace
 signconfig.xml
-workspaceinfo.xml
-directory.build.props
+WorkspaceInfo.xml
+Directory.Build.props

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,3 +10,6 @@ tslint.json
 sariftypesgenerator/**
 samples/**
 workspace.code-workspace
+signconfig.xml
+workspaceinfo.xml
+directory.build.props

--- a/signconfig.xml
+++ b/signconfig.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?> 
+<SignConfigXML> 
+<job platform="" configuration="release" dest="" jobname="SARIF Viewer VSIX Signinging" approvers="gabrield"> 
+<file src="__INPATHROOT__\Microsoft.Sarif-Viewer.vsix" signType="100040160" dest="__OUTPATHROOT__\Microsoft.Sarif-Viewer.vsix" /> 
+</job> 
+</SignConfigXML>


### PR DESCRIPTION
This address issue #265 . The configuration file is used by Azure Dev Ops (ADO) build pipeline to embed an X509 digital certificate in the VSIX package.

The additions to .vscodeingore are needed to remove files that are automatically inserted by the ADO build pipeline into the source tree during the build.