### PR TITLE
Implement update mechanism for Inisiders Channel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "out": true // set this to false to include "out" folder in search results
     },
     "cSpell.words": [
-        "SARIF"
+        "SARIF",
+        "vsix"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,9 +112,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "7.10.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.7.tgz",
-            "integrity": "sha512-4I7+hXKyq7e1deuzX9udu0hPIYqSSkdKXtjow6fMnQ3OR9qkxIErGHbGY08YrfZJrCS1ajK8lOuzd0k3n2WM4A==",
+            "version": "13.13.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
+            "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
             "dev": true
         },
         "@types/sarif": {
@@ -122,6 +122,15 @@
             "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.2.tgz",
             "integrity": "sha512-TELZl5h48KaB6SFZqTuaMEw1hrGuusbBcH+yfMaaHdS2pwDr3RTH4CVN0LyY1kqSiDm9PPvAMx8FJ0LUZreOCQ==",
             "dev": true
+        },
+        "@types/semver": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
+            "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/sizzle": {
             "version": "2.3.2",
@@ -348,6 +357,14 @@
                 "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
             }
         },
         "dashdash": {
@@ -644,16 +661,6 @@
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
-        "http-proxy-agent": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-            "dev": true,
-            "requires": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-            }
-        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -666,13 +673,35 @@
             }
         },
         "https-proxy-agent": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-            "dev": true,
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
             "requires": {
-                "agent-base": "^4.3.0",
-                "debug": "^3.1.0"
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+                    "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+                    "requires": {
+                        "debug": "4"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
             }
         },
         "inflight": {
@@ -1048,6 +1077,14 @@
             "requires": {
                 "object.getownpropertydescriptors": "^2.0.3",
                 "semver": "^5.7.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
             }
         },
         "npm-run-path": {
@@ -1298,10 +1335,9 @@
             "dev": true
         },
         "semver": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-            "dev": true
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+            "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -1465,6 +1501,12 @@
                     "requires": {
                         "minimist": "^1.2.5"
                     }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
                 }
             }
         },
@@ -1641,6 +1683,12 @@
                         }
                     }
                 },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
                 "supports-color": {
                     "version": "5.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -1658,6 +1706,28 @@
                     "requires": {
                         "http-proxy-agent": "^2.1.0",
                         "https-proxy-agent": "^2.2.1"
+                    },
+                    "dependencies": {
+                        "http-proxy-agent": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+                            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+                            "dev": true,
+                            "requires": {
+                                "agent-base": "4",
+                                "debug": "3.1.0"
+                            }
+                        },
+                        "https-proxy-agent": {
+                            "version": "2.2.4",
+                            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+                            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+                            "dev": true,
+                            "requires": {
+                                "agent-base": "^4.3.0",
+                                "debug": "^3.1.0"
+                            }
+                        }
                     }
                 }
             }
@@ -1675,6 +1745,28 @@
             "requires": {
                 "http-proxy-agent": "^2.1.0",
                 "https-proxy-agent": "^2.2.1"
+            },
+            "dependencies": {
+                "http-proxy-agent": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+                    "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "4",
+                        "debug": "3.1.0"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+                    "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^4.3.0",
+                        "debug": "^3.1.0"
+                    }
+                }
             }
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,24 @@
                                 "sarifFile",
                                 "severityLevel",
                                 "tool"
-                            ]
+                            ],
+                            "enumDescriptions": [
+                                "%automationCat.description%",
+                                "%automationId.description%",
+                                "%baselineState.description%",
+                                "%kind.description%",
+                                "%message.description%",
+                                "%rank.description%",
+                                "%resultFile.description%",
+                                "%resultStartPos.description%",
+                                "%logicalLocation.description%",
+                                "%ruleId.description%",
+                                "%ruleName.description%",
+                                "%runId.description%",
+                                "%sarifFile.description%",
+                                "%severityLevel.description%",
+                                "%tool.description%"
+                            ]        
                         },
                         "ascending": {
                             "type": "boolean"
@@ -194,6 +211,20 @@
                     "description": "%sarif-viewer.openMarkdownPreview.description%",
                     "type": "boolean",
                     "default": false,
+                    "scope": "application"
+                },
+                "sarif-viewer.updateChannel": {
+                    "description": "%sarif-viewer.updateChannel.description%",
+                    "type": "string",
+                    "enum": [
+                        "Default",
+                        "Insiders"
+                    ],
+                    "enumDescriptions": [
+                        "%sarif-viewer.updateChannel.default.description%",
+                        "%sarif-viewer.updateChannel.insiders.description%"
+                    ],
+                    "default": "Default",
                     "scope": "application"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
                                 "%sarifFile.description%",
                                 "%severityLevel.description%",
                                 "%tool.description%"
-                            ]        
+                            ]
                         },
                         "ascending": {
                             "type": "boolean"

--- a/package.json
+++ b/package.json
@@ -257,11 +257,12 @@
         "installNodeModules": "npm install"
     },
     "devDependencies": {
+        "@types/semver": "^7.1.0",
         "@types/glob": "^7.1.1",
         "@types/jquery": "^3.3.30",
         "@types/markdown-it": "0.0.9",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^7.10.7",
+        "@types/node": "^13.13.2",
         "@types/sarif": "^2.1.2",
         "mocha": "^6.2.0",
         "tslint-microsoft-contrib": "^6.0.0",
@@ -272,11 +273,13 @@
         "tslint": "^6.1.1"
     },
     "dependencies": {
+        "semver": "^7.3.2",
         "@microsoft/sarif-multitool": "^2.2.3",
         "json-source-map": "^0.4.0",
         "jsonpointer": "4.0.1",
         "markdown-it": "^9.0.1",
         "requirejs": "^2.3.6",
-        "vscode-nls": "^4.1.2"
+        "vscode-nls": "^4.1.2",
+        "https-proxy-agent": "^5.0.0"
     }
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -125,5 +125,8 @@
     "sarif-viewer.explorer.openWhenNoResults.description": "Indicates whether to open the explorer when there are no results in the log.",
     "sarif-viewer.binaryArtifactContent.bytesPerRow.description": "When rendering binary artifact content, determines the number of bytes displayed in a row.",
     "sarif-viewer.binaryArtifactContent.viewAsMarkdown.description": "When enabled, renders binary artifact content as markdown.",
-    "sarif-viewer.openMarkdownPreview.description": "When viewing artifact content containing markdown, show the markdown preview."
+    "sarif-viewer.openMarkdownPreview.description": "When viewing artifact content containing markdown, show the markdown preview.",
+    "sarif-viewer.updateChannel.description": "Specifies the type of updates the extension receives.",
+    "sarif-viewer.updateChannel.default.description%": "Insiders channel. Receives upcoming features and bug fixes at a faster rate.",
+    "sarif-viewer.updateChannel.insiders.description%": "Default channel."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -127,6 +127,6 @@
     "sarif-viewer.binaryArtifactContent.viewAsMarkdown.description": "When enabled, renders binary artifact content as markdown.",
     "sarif-viewer.openMarkdownPreview.description": "When viewing artifact content containing markdown, show the markdown preview.",
     "sarif-viewer.updateChannel.description": "Specifies the type of updates the extension receives.",
-    "sarif-viewer.updateChannel.default.description%": "Insiders channel. Receives upcoming features and bug fixes at a faster rate.",
-    "sarif-viewer.updateChannel.insiders.description%": "Default channel."
+    "sarif-viewer.updateChannel.insiders.description": "Insiders channel. Receives upcoming features and bug fixes at a faster rate.",
+    "sarif-viewer.updateChannel.default.description": "Default channel."
 }

--- a/signconfig.xml
+++ b/signconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?> 
 <SignConfigXML> 
 <job platform="" configuration="release" dest="" jobname="SARIF Viewer VSIX Signinging" approvers="gabrield"> 
-<file src="__INPATHROOT__\Microsoft.Sarif-Viewer.vsix" signType="100040160" dest="__OUTPATHROOT__\Microsoft.Sarif-Viewer.vsix" /> 
+<file src="__INPATHROOT__\MS-SarifVSCode.sarif-viewer.vsix" signType="100040160" dest="__OUTPATHROOT__\MS-SarifVSCode.sarif-viewer.vsix" /> 
 </job> 
 </SignConfigXML>

--- a/signconfig.xml
+++ b/signconfig.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?> 
-<SignConfigXML> 
-<job platform="" configuration="release" dest="" jobname="SARIF Viewer VSIX Signinging" approvers="gabrield"> 
-<file src="__INPATHROOT__\MS-SarifVSCode.sarif-viewer.vsix" signType="100040160" dest="__OUTPATHROOT__\MS-SarifVSCode.sarif-viewer.vsix" /> 
-</job> 
-</SignConfigXML>

--- a/src/artifactContentFileSystemProvider.ts
+++ b/src/artifactContentFileSystemProvider.ts
@@ -267,7 +267,7 @@ export class ArtifactContentFileSystemProvider implements vscode.FileSystemProvi
             artifactUri: artifactUri.toString(/*skpEncoding*/ true)
         };
 
-        const encodedUriDataAsBase64: string = new Buffer(JSON.stringify(encodedUriData)).toString('base64');
+        const encodedUriDataAsBase64: string = Buffer.from(JSON.stringify(encodedUriData)).toString('base64');
 
         return vscode.Uri.parse(`${ArtifactContentFileSystemProvider.ArtifactContentScheme}://${uriPath}?${encodedUriDataAsBase64}`, /*strict*/ true);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { OpenLogArguments, Api } from "./api/sarifViewerApi";
 // If you don't do this... you crash using the extension methods.
 import './utilities/stringUtilities';
 import { ArtifactContentFileSystemProvider } from './artifactContentFileSystemProvider';
+import { checkForInsiderUpdates } from './insidersUpdate/updateCheck';
 
 export function activate(context: vscode.ExtensionContext): Api {
     return new SarifExtension(context);
@@ -100,6 +101,8 @@ class SarifExtension implements Api {
 
         // We do not need to block extension startup for reading any open documents.
         void this.readOpenedDocuments();
+
+        void checkForInsiderUpdates();
     }
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,8 @@ import { OpenLogArguments, Api } from "./api/sarifViewerApi";
 // If you don't do this... you crash using the extension methods.
 import './utilities/stringUtilities';
 import { ArtifactContentFileSystemProvider } from './artifactContentFileSystemProvider';
-import { checkForInsiderUpdates } from './insidersUpdate/updateCheck';
+import { checkForInsiderUpdates, DefaultUpdateChannel, UpdateChannel, UpdateChannelSetting } from './insidersUpdate/updateCheck';
+import * as DebugUtilities from "./utilities/debugUtilities";
 
 export function activate(context: vscode.ExtensionContext): Api {
     return new SarifExtension(context);
@@ -102,7 +103,7 @@ class SarifExtension implements Api {
         // We do not need to block extension startup for reading any open documents.
         void this.readOpenedDocuments();
 
-        void checkForInsiderUpdates();
+        this.startInsidersUpdateChecks(context);
     }
 
     /**
@@ -258,5 +259,30 @@ class SarifExtension implements Api {
         this.diagnosticCollection.removeAllRuns();
 
         return;
+    }
+
+    /**
+     * Starts checks for insiders.
+     * @param context The VSCode extension context.
+     */
+    private startInsidersUpdateChecks(context: vscode.ExtensionContext): void {
+        if (DebugUtilities.debugMode || DebugUtilities.testMode) {
+            return;
+        }
+
+        const checkForUpdates: () => void = () => {
+            const updateChannel: UpdateChannel =  vscode.workspace.getConfiguration(Utilities.configSection).get(UpdateChannelSetting, DefaultUpdateChannel);
+            if (updateChannel === 'Insiders') {
+                void checkForInsiderUpdates('Install');
+            }
+        };
+
+        context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((configurationChangeEvent) => {
+            if (configurationChangeEvent.affectsConfiguration(UpdateChannelSetting)) {
+                checkForUpdates();
+            }
+        }));
+
+        checkForUpdates();
     }
 }

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -289,11 +289,11 @@ export class FileConverter {
             // can be over-ridden for testing.
             const proc: ChildProcess = spawn(FileConverter.multiToolPath, ['transform', sarifFile.fsPath, '-o', fileOutputPath, '-p', '-f']);
 
-            proc.stderr.on('data', (data) => {
+            proc.stderr?.on('data', (data) => {
                 errorData.push(data.toString());
             });
 
-            proc.stdout.on('data', (data) => {
+            proc.stdout?.on('data', (data) => {
                 errorData.push(data.toString());
             });
 

--- a/src/insidersUpdate/gitHubInterfaces.ts
+++ b/src/insidersUpdate/gitHubInterfaces.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ */
+
+/**
+ * For reference, you can find the GitHub API information here:
+ * https://developer.github.com/v3/repos/
+ */
+
+export const GitHubApiBase: string = 'https://api.github.com/repos';
+
+ /**
+  * Contains the minimum information needed to inspect a git-hub release.
+  */
+export interface GitHubRelease {
+    /**
+     * The tag name for the release in the form of v<semver>-insiders.
+     * I.e. v3.2020.424006-insiders
+     */
+    readonly tag_name: string;
+
+    /**
+     * The Git Hub release ID.
+     */
+    readonly id: number;
+
+    /**
+     * The URL for the asset which will be used to download the extension.
+     */
+    readonly assets_url: string;
+}
+
+ /**
+  * Contains the minimum information needed to inspect a git-hub asset.
+  */
+ export interface GitHubAsset {
+
+    /**
+     * The URI of the asset to download.
+     */
+    readonly browser_download_url: string;
+
+    /**
+     * We expect this to be "application/octet-stream"
+     */
+    readonly content_type: string;
+
+    /**
+     * The name of the asset.
+     * Should be Microsoft.Sarif-Viewer.vsix.
+     */
+    readonly name: string;
+}

--- a/src/insidersUpdate/gitHubInterfaces.ts
+++ b/src/insidersUpdate/gitHubInterfaces.ts
@@ -5,9 +5,14 @@
 /**
  * For reference, you can find the GitHub API information here:
  * https://developer.github.com/v3/repos/
+ * Yes, there are "node packages" from just about everyone but they are
+ * way overkill for what we need. These interfaces are the bare-minimum
+ * needed for us to perform our upgrade checks and installs.
+ * This implementation was adapted from the Microsoft C/C++ extension.
+ * https://github.com/microsoft/vscode-cpptools/blob/58c50dc38b1a3ebcae8139b28c0904d468d11e6e/Extension/src/githubAPI.ts
  */
 
-export const GitHubApiBase: string = 'https://api.github.com/repos';
+export const GitHubApiBase: string = 'https://api.github.com';
 
  /**
   * Contains the minimum information needed to inspect a git-hub release.
@@ -50,4 +55,39 @@ export interface GitHubRelease {
      * Should be Microsoft.Sarif-Viewer.vsix.
      */
     readonly name: string;
+}
+
+/**
+ * Rate limit information from GitHub.
+ */
+export interface GitHubRateLimit {
+    /**
+     * The total rate-limit.
+     */
+    limit: number;
+
+    /**
+     * The number of queries we have remaining.
+     */
+    remaining: number;
+
+    /**
+     * The time at which the rate-limit resets.
+     */
+    reset: number;
+}
+
+/**
+ * The rate limits for different GitHub resources.
+ * We only use the core one.
+ */
+export interface GitHubRateResources {
+    core: GitHubRateLimit;
+}
+
+/**
+ * Contains the response from https://developer.github.com/v3/rate_limit/
+ */
+export interface GitHubRateLimitResponse {
+    resources: GitHubRateResources;
 }

--- a/src/insidersUpdate/updateCheck.ts
+++ b/src/insidersUpdate/updateCheck.ts
@@ -1,0 +1,229 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ */
+
+import * as vscode from "vscode";
+import * as https from "https";
+import * as fs from "fs";
+import * as semver from "semver";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { OutgoingHttpHeaders, ClientRequest } from 'http';
+import * as URL from 'url';
+import { Utilities } from "../utilities";
+import { GitHubRelease, GitHubApiBase, GitHubAsset } from "./gitHubInterfaces";
+
+const sarifRepo: string = 'Microsoft/sarif-vscode-extension';
+const vsixName: string = 'Microsoft.Sarif-Viewer.vsix';
+const maxRedirectionAllowed: number = 3;
+const maxNUmberOfReleasesToInspect: number = 4;
+
+/**
+ * Retrieves @see HttpsProxyAgent information that may be setup in VSCode or in the process environment.
+ */
+function getHttpsProxyAgent(): HttpsProxyAgent | undefined {
+    // See if we have an HTTP proxy set up in VSCode's proxy settings or
+    // if it has been set up in the process environment.
+    // NOTE: The upper and lower case versions are best attempt effort as enumerating through
+    // all the environment key\value pairs to perform case insensitive compares for "http(s)_proxy"
+    // would be a bit too much.
+    const proxy: string | undefined = vscode.workspace.getConfiguration().get<string | undefined>('http.proxy', undefined) ||
+        process.env.HTTPS_PROXY ||
+        process.env.https_proxy ||
+        process.env.HTTP_PROXY ||
+        process.env.http_proxy;
+
+    // If no proxy is defined, we're done
+    if (!proxy) {
+        return undefined;
+    }
+
+    const proxyUrl: URL.Url = URL.parse(proxy);
+
+    if (!proxyUrl.protocol || (!proxyUrl.protocol.invariantEqual('https:') && !proxyUrl.protocol.invariantEqual('http:'))) {
+        return undefined;
+    }
+
+    return new HttpsProxyAgent({
+        port: proxyUrl.port && parseInt(proxyUrl.port, 10),
+        host: proxyUrl.host,
+        auth: proxyUrl.auth,
+        secureProxy: vscode.workspace.getConfiguration().get('http.proxyStrictSSL', true)
+    });
+
+}
+
+/**
+ * Downloads content into a file over HTTPS.
+ * @param uri The URI to download.
+ * @param destinationPath  The destination path for the download.
+ * @param headers Optional headers to use for the download.
+ * @param redirectionCount The number of times a redirection has been attempted.
+ */
+async function downloadOverHttps(uri: vscode.Uri, destinationPath: vscode.Uri, headers?: OutgoingHttpHeaders, redirectionCount?: number): Promise<void> {
+    if (!destinationPath.isFile()) {
+        throw new Error('Destination path is expected to be a file.');
+    }
+
+    const redirectionAttempts: number = redirectionCount ?? 0;
+    const requestPromise: Promise<void> = new Promise<void>((resolve, reject) => {
+        const parsedUrl: URL.Url = URL.parse(uri.toString(/*skip encoding*/ true));
+        const httpRequest: ClientRequest = https.request({
+            headers,
+            path: parsedUrl.path,
+            host: parsedUrl.host,
+            agent: getHttpsProxyAgent(),
+            rejectUnauthorized: vscode.workspace.getConfiguration().get('http.proxyStrictSSL', true)
+        }, async (response) => {
+            // Handle redirection but don't let it run forever.
+            if ((response.statusCode === 301 || response.statusCode === 302) && response.headers.location && redirectionAttempts < maxRedirectionAllowed) {
+                resolve(downloadOverHttps(vscode.Uri.parse(response.headers.location, /*strict*/ true), destinationPath, headers, redirectionAttempts + 1));
+                return;
+            }
+
+            if (response.statusCode !== 200) {
+                reject(new Error(`Update checked failed downloading from ${uri.toString(/*skip encoding*/ true)} with status code ${response.statusCode}`));
+                return;
+            }
+
+            const createdFile: fs.WriteStream = fs.createWriteStream(destinationPath.fsPath);
+            createdFile.on('finish', () => {
+                resolve();
+            });
+
+            response.on('error', (error) => {
+                reject(error);
+                return;
+            });
+            response.pipe(createdFile);
+        });
+
+        httpRequest.on('error', (error) => {
+            reject(error);
+            return;
+        });
+
+        httpRequest.end();
+    });
+
+    await requestPromise;
+}
+
+/**
+ * Downloads content and parses it into an object (assumes the downloaded content is JSON).
+ * @param uri The URI to download.
+ * @param downloadName A name (file name portion) that will be used in a temporary full path for downloading content.
+ * @param headers Optional headers to use for the download.
+ */
+async function downloadOverHttpsAsJsonObject<T>(uri: vscode.Uri, downloadName: string, headers?: OutgoingHttpHeaders): Promise<T> {
+    const downloadUri: vscode.Uri = vscode.Uri.file(Utilities.generateTempPath(downloadName));
+    await downloadOverHttps(uri, downloadUri, headers);
+    const jsonBuffer: Buffer = await new Promise<Buffer>((resolve, reject) => {
+        fs.readFile(downloadUri.fsPath, (err, data) => {
+            err ? reject(err) : resolve(data);
+        });
+    });
+    return <T>JSON.parse(jsonBuffer.toString());
+}
+
+/**
+ * Uses GitHub release APIs to attempt to locate an acceptable release to upgrade to.
+ */
+async function findInsidersReleaseCandidate(): Promise<GitHubRelease | undefined> {
+    const ourExtension: vscode.Extension<void> | undefined = vscode.extensions.getExtension('MS-SarifVSCode.sarif-viewer');
+    if (!ourExtension) {
+        throw new Error('Cannot find our own extension???');
+    }
+
+    const versionString: string | undefined = ourExtension.packageJSON.version;
+    if (!versionString) {
+        throw new Error('Cannot find our own extension version???');
+    }
+
+    const headers: OutgoingHttpHeaders = { 'User-Agent': 'microsoft.sarif-viewer' };
+    const gitHubReleaseResponse: GitHubRelease[] = await downloadOverHttpsAsJsonObject(vscode.Uri.parse(`${GitHubApiBase}/${sarifRepo}/releases`), 'gitHubReleases.json', headers);
+
+    const releasesToInspect: GitHubRelease[] = gitHubReleaseResponse.slice(0, maxNUmberOfReleasesToInspect);
+    for (const release of releasesToInspect) {
+        if (!release.tag_name.charAt(0).invariantEqual('v')) {
+            continue;
+        }
+
+        const candidateReleaseVersion: semver.SemVer = new semver.SemVer(release.tag_name.substr(1));
+        if (candidateReleaseVersion.prerelease.find((tag) => typeof tag === 'string' && tag.invariantEqual('insiders')) === undefined) {
+            continue;
+        }
+
+        const extensionVersion: semver.SemVer = new semver.SemVer(versionString);
+        if (candidateReleaseVersion.compare(extensionVersion) <= 0) {
+            continue;
+        }
+
+        return release;
+    }
+
+    return undefined;
+}
+
+/**
+ * Attempts to locate a GitHub asset (which is our Download VSIX) using GitHub APIs.
+ * @param release A candidate release found from @see findInsidersReleaseCandidate
+ */
+async function findAssetForRelease(release: GitHubRelease): Promise<GitHubAsset | undefined> {
+    const headers: OutgoingHttpHeaders = { 'User-Agent': 'microsoft.sarif-viewer' };
+    const gitHubAssets: GitHubAsset[] = await downloadOverHttpsAsJsonObject(vscode.Uri.parse(`${GitHubApiBase}/${sarifRepo}/releases/${release.id}/assets`), 'githubAssets.json', headers);
+    for (const asset of gitHubAssets) {
+        if (asset.content_type.invariantEqual('application/octet-stream', 'Ignore Case') &&
+            asset.name.invariantEqual(vsixName, 'Ignore Case')) {
+                return asset;
+        }
+    }
+
+    return undefined;
+}
+
+async function tryDownloadVsix(asset: GitHubAsset): Promise<vscode.Uri | undefined> {
+    let success: boolean = false;
+    const vsixDownloadUri: vscode.Uri = vscode.Uri.file(Utilities.generateTempPath(vsixName));
+    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+    const originalProxySupport: string | undefined = config.inspect<string>('http.proxySupport')?.globalValue;
+    let tryAgain: boolean = true;
+    while (tryAgain && !success) {
+        try {
+            await downloadOverHttps(vscode.Uri.parse(asset.browser_download_url, /*strict*/ true), vsixDownloadUri);
+            success = true;
+        } catch {
+            if (config.get('http.proxySupport', undefined) !== 'off' && originalProxySupport !== 'off') {
+                await config.update('http.proxySupport', 'off', true);
+                continue;
+            }
+
+            tryAgain = false;
+        }
+
+        if (originalProxySupport !== config.inspect<string>('http.proxySupport')?.globalValue) {
+            await config.update('http.proxySupport', originalProxySupport, true); // Reset the http.proxySupport.
+            tryAgain = false;
+        }
+    }
+
+    return success ? vsixDownloadUri : undefined;
+}
+
+export async function checkForInsiderUpdates(): Promise<void> {
+    const gitHubRelease: GitHubRelease | undefined = await findInsidersReleaseCandidate();
+    if (!gitHubRelease) {
+        return;
+    }
+
+    const gitHubAsset: GitHubAsset | undefined = await findAssetForRelease(gitHubRelease);
+    if (!gitHubAsset) {
+        return;
+    }
+
+    const vsixUri: vscode.Uri | undefined = await tryDownloadVsix(gitHubAsset);
+    if (!vsixUri) {
+        return;
+    }
+
+    await vscode.commands.executeCommand('workbench.extensions.installExtension', vsixUri);
+}

--- a/src/insidersUpdate/updateCheck.ts
+++ b/src/insidersUpdate/updateCheck.ts
@@ -165,8 +165,8 @@ async function findInsidersReleaseCandidate(): Promise<GitHubRelease | undefined
         throw new Error('Cannot find our own extension???');
     }
 
-    const versionString: string | undefined = ourExtension.packageJSON.version;
-    if (!versionString) {
+    const ourVersionString: string | undefined = ourExtension.packageJSON.version;
+    if (!ourVersionString) {
         throw new Error('Cannot find our own extension version???');
     }
 
@@ -183,13 +183,7 @@ async function findInsidersReleaseCandidate(): Promise<GitHubRelease | undefined
             continue;
         }
 
-        const candidateReleaseVersion: semver.SemVer = new semver.SemVer(release.tag_name.substr(1));
-        if (candidateReleaseVersion.prerelease.find((tag) => typeof tag === 'string' && tag.invariantEqual('insiders')) === undefined) {
-            continue;
-        }
-
-        const extensionVersion: semver.SemVer = new semver.SemVer(versionString);
-        if (semver.lte(releaseSemVer, extensionVersion)) {
+        if (!semver.lte(ourVersionString, releaseSemVer)) {
             continue;
         }
 

--- a/src/insidersUpdate/updateCheck.ts
+++ b/src/insidersUpdate/updateCheck.ts
@@ -250,7 +250,7 @@ async function tryDownloadVsix(asset: GitHubAsset): Promise<vscode.Uri | undefin
     return undefined;
 }
 
-async function checkForInsiderUpdatesImpl(installOptions: 'Install' | 'Just check') : Promise<boolean> {
+async function checkForInsiderUpdatesImpl(installOptions: 'Install' | 'Just check'): Promise<boolean> {
     // If we have exceeded the rate limit (which actually would be hard to do since the limit is 60 per hour per IP
     // for unauthorized requests), then we can't really do much.
     // https://developer.github.com/v3/#rate-limiting

--- a/src/insidersUpdate/updateCheck.ts
+++ b/src/insidersUpdate/updateCheck.ts
@@ -172,6 +172,12 @@ async function findInsidersReleaseCandidate(): Promise<GitHubRelease | undefined
 
     const gitHubReleaseResponse: GitHubRelease[] = await downloadOverHttpsAsJsonObject(vscode.Uri.parse(`${GitHubApiBase}/repos/${gitHubRepo}/releases`), 'gitHubReleases.json', userAgentHeaders);
 
+    // How the releases would look on the GitHub releases page
+    // Master = 3.4.0
+    // Insiders = 3.3.9
+    // Insiders = 3.3.8
+    // Master = 3.3.7
+    // The goal is to skip the master releases and only look for the insider ones.
     const releasesToInspect: GitHubRelease[] = gitHubReleaseResponse.slice(0, maxNUmberOfReleasesToInspect);
     for (const release of releasesToInspect) {
         if (!release.tag_name.charAt(0).invariantEqual('v')) {
@@ -183,7 +189,9 @@ async function findInsidersReleaseCandidate(): Promise<GitHubRelease | undefined
             continue;
         }
 
-        if (semver.lte(currentlyInstalledVersion, gitHubReleaseVersion)) {
+        // currentlyInstalledVersion = 1.2.3
+        // gitHubReleaseVersion = 4.5.6
+        if (semver.gte(currentlyInstalledVersion, gitHubReleaseVersion)) {
             continue;
         }
 

--- a/src/insidersUpdate/updateCheck.ts
+++ b/src/insidersUpdate/updateCheck.ts
@@ -165,8 +165,8 @@ async function findInsidersReleaseCandidate(): Promise<GitHubRelease | undefined
         throw new Error('Cannot find our own extension???');
     }
 
-    const ourVersionString: string | undefined = ourExtension.packageJSON.version;
-    if (!ourVersionString) {
+    const currentlyInstalledVersion: string | undefined = ourExtension.packageJSON.version;
+    if (!currentlyInstalledVersion) {
         throw new Error('Cannot find our own extension version???');
     }
 
@@ -178,12 +178,12 @@ async function findInsidersReleaseCandidate(): Promise<GitHubRelease | undefined
             continue;
         }
 
-        const releaseSemVer: string = release.tag_name.substr(1);
-        if (!semver.prerelease(releaseSemVer)?.some((tag) => tag.invariantEqual('insiders'))) {
+        const gitHubReleaseVersion: string = release.tag_name.substr(1);
+        if (!semver.prerelease(gitHubReleaseVersion)?.some((tag) => tag.invariantEqual('insiders'))) {
             continue;
         }
 
-        if (!semver.lte(ourVersionString, releaseSemVer)) {
+        if (semver.lte(currentlyInstalledVersion, gitHubReleaseVersion)) {
             continue;
         }
 

--- a/src/test/insiderUpgrade.test.ts
+++ b/src/test/insiderUpgrade.test.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ */
+import * as assert from "assert";
+import { checkForInsiderUpdates } from "../insidersUpdate/updateCheck";
+
+suite("testUpgradeCheck",async function (this: Mocha.Suite): Promise<void> {
+    test("Make sure Insiders version can be found", async function (this: Mocha.Context): Promise<void> {
+        this.timeout('60s');
+        assert.equal(await checkForInsiderUpdates('Just check'), true);
+    });
+});

--- a/src/utilities/debugUtilities.ts
+++ b/src/utilities/debugUtilities.ts
@@ -10,11 +10,7 @@ export const testMode: boolean = startedInTestMode();
  * A helper for detecting whether the extension was started in a test.
  */
 function startedInTestMode(): boolean {
-    const args: string[] = process.execArgv;
-    if (args) {
-        return args.some((arg) => /^--extensionTestsPath=?/.test(arg));
-    }
-    return false;
+    return process.execArgv.some((arg) => /^--extensionTestsPath=?/.test(arg));
 }
 
 /**
@@ -22,9 +18,5 @@ function startedInTestMode(): boolean {
  * Borrowed from: https://github.com/Microsoft/vscode-languageserver-node/blob/db0f0f8c06b89923f96a8a5aebc8a4b5bb3018ad/client/src/main.ts#L217
  */
 function startedInDebugMode(): boolean {
-    const args: string[] = process.execArgv;
-    if (args) {
-        return args.some((arg) => /^--debug=?/.test(arg) || /^--debug-brk=?/.test(arg) || /^--inspect=?/.test(arg) || /^--inspect-brk=?/.test(arg));
-    }
-    return false;
+    return process.execArgv.some((arg) => /^--debug=?/.test(arg) || /^--debug-brk=?/.test(arg) || /^--inspect=?/.test(arg) || /^--inspect-brk=?/.test(arg));
 }

--- a/src/utilities/debugUtilities.ts
+++ b/src/utilities/debugUtilities.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ */
+
+export const debugMode: boolean = startedInDebugMode();
+
+export const testMode: boolean = startedInTestMode();
+
+/**
+ * A helper for detecting whether the extension was started in a test.
+ */
+function startedInTestMode(): boolean {
+    const args: string[] = process.execArgv;
+    if (args) {
+        return args.some((arg) => /^--extensionTestsPath=?/.test(arg));
+    }
+    return false;
+}
+
+/**
+ * A helper for detecting whether the extension was started in debug mode.
+ * Borrowed from: https://github.com/Microsoft/vscode-languageserver-node/blob/db0f0f8c06b89923f96a8a5aebc8a4b5bb3018ad/client/src/main.ts#L217
+ */
+function startedInDebugMode(): boolean {
+    const args: string[] = process.execArgv;
+    if (args) {
+        return args.some((arg) => /^--debug=?/.test(arg) || /^--debug-brk=?/.test(arg) || /^--inspect=?/.test(arg) || /^--inspect-brk=?/.test(arg));
+    }
+    return false;
+}


### PR DESCRIPTION
Now that we have Insiders releases being created on GitHub's releases automatically through our ADO build pipeline, we can now create an update mechanisms for those insiders.

The idea is pretty simple and was adapted from the [Microsoft C/C++ extension](https://github.com/microsoft/vscode-cpptools).

Use the GitHub APIs to read the releases and look at the tags (which are the version numbers). If there is a newer insiders version number, then look for the "asset" (again using the git-hub API) for that release that has our VSIX name in it. Download that VSIX, install it, and prompt the user to reload.

That's basically it.

There is some special handing (also adapted from the Microsoft C/C++ extension) to handle rate limits and HTTP proxy setups.