### PR TITLE
Please, no more upgrade prompts :)

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,20 @@
                     "type": "boolean",
                     "default": false,
                     "scope": "application"
+                },
+                "sarif-viewer.logUpgrade.prompt": {
+                    "description": "%sarif-viewer.logUpgrade.prompt.description%",
+                    "type": "string",
+                    "enum": [
+                        "Prompt",
+                        "Temporary"
+                    ],
+                    "enumDescriptions": [
+                        "%sarif-viewer.logUpgrade.prompt.prompt.description%",
+                        "%sarif-viewer.logUpgrade.prompt.temporary.description%"
+                    ],
+                    "default": "Prompt",
+                    "scope": "application"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -218,11 +218,11 @@
                     "type": "string",
                     "enum": [
                         "Prompt",
-                        "Temporary"
+                        "Always"
                     ],
                     "enumDescriptions": [
                         "%sarif-viewer.logUpgrade.prompt.prompt.description%",
-                        "%sarif-viewer.logUpgrade.prompt.temporary.description%"
+                        "%sarif-viewer.logUpgrade.prompt.always.description%"
                     ],
                     "default": "Prompt"
                 },

--- a/package.nls.json
+++ b/package.nls.json
@@ -26,31 +26,6 @@
 
     "explorer.Title": "SARIF Explorer",
 
-    "codeFlow.HoverMessage": "[Code Flow] {0}",
-    "converterTool.AndroidStudio": "Android Studio",
-    "converterTool.ClangAnalyzer": "CLang Analyzer",
-    "converterTool.CppCheck": "CppCheck",
-    "converterTool.ContrastSecurity": "Contrast Security",
-    "converterTool.Fortify": "Fortify",
-    "converterTool.FortifyFpr": "Fortify Fpr",
-    "converterTool.FxCop": "FxCop",
-    "converterTool.PREfast": "PREfast",
-    "converterTool.Pylint": "Pylint",
-    "converterTool.SemmleQL": "Semmle QL",
-    "converterTool.StaticDriverVerifier": "Static Driver Verifier",
-    "converterTool.TSLint": "TSLint",
-    "converterTool.AllFiles": "All Files",
-    "converterTool.OpenFileDialogTitle": "{0} log files",
-
-    "converterTool.UpgradedErrorMessage": "Sarif version '{0}'(schema '{1}') is not yet supported by the Viewer. Make sure you have the latest extension version and check https://github.com/Microsoft/sarif-vscode-extension for future support.`",
-    "converterTool.Upgrade.SaveTemp": "Yes (Save Temp)",
-    "converterTool.Upgrade.SaveAs": "Yes (Save As)",
-    "converterTool.Upgrade.No": "No",
-    "converterTool.Upgrade.FailedMessage": "Sarif upgrade failed with error: {0}",
-    "converterTool.Upgrade.AskWithSchema": "Sarif schema version {0} is not supported. Upgrade to the latest schema version {1}?",
-    "converterTool.Upgrade.AskWithVersion": "Sarif version {0} is not supported. Upgrade to the latest version {1}?",
-    "converterTool.Upgrade.UnknownVersion": "Unknown",
-
     "openRemappingInputDialog.title": "Sarif Result Location Remapping",
     "openRemappingInputDialog.prompt": "Valid path, confirm if it maps to '{0}' or its rootpath",
     "openRemappingInputDialog.validationMessage": "'{0}' can not be found.\r\nCorrect the path to: the local file (c:/example/repo1/source.js) for this session or the local rootpath (c:/example/repo1/) to add it to the user settings (Press 'Escape' to cancel)",
@@ -125,5 +100,9 @@
     "sarif-viewer.explorer.openWhenNoResults.description": "Indicates whether to open the explorer when there are no results in the log.",
     "sarif-viewer.binaryArtifactContent.bytesPerRow.description": "When rendering binary artifact content, determines the number of bytes displayed in a row.",
     "sarif-viewer.binaryArtifactContent.viewAsMarkdown.description": "When enabled, renders binary artifact content as markdown.",
-    "sarif-viewer.openMarkdownPreview.description": "When viewing artifact content containing markdown, show the markdown preview."
+    "sarif-viewer.openMarkdownPreview.description": "When viewing artifact content containing markdown, show the markdown preview.",
+
+    "sarif-viewer.logUpgrade.prompt.description": "Determines how files are created when a SARIF log needs to be upgraded from an earlier schema.",
+    "sarif-viewer.logUpgrade.prompt.prompt.description": "Prompt for upgrade.",
+    "sarif-viewer.logUpgrade.prompt.temporary.description": "A temporary file  for the upgraded SARIF log is created, no prompt is shown."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -104,7 +104,7 @@
 
     "sarif-viewer.logUpgrade.prompt.description": "Determines how files are created when a SARIF log needs to be upgraded from an earlier schema.",
     "sarif-viewer.logUpgrade.prompt.prompt.description": "Prompt for upgrade.",
-    "sarif-viewer.logUpgrade.prompt.temporary.description": "A temporary file  for the upgraded SARIF log is created, no prompt is shown.",
+    "sarif-viewer.logUpgrade.prompt.always.description": "A temporary file for the upgraded SARIF log is created, no prompt is shown.",
 
     "sarif-viewer.updateChannel.description": "Specifies the type of updates the extension receives.",
     "sarif-viewer.updateChannel.insiders.description": "Insiders channel. Receives upcoming features and bug fixes at a faster rate.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -242,7 +242,7 @@ class SarifExtension implements Api {
                 openViewerWhenNoResults: openLogFileArguments?.openViewerWhenNoResults,
                 closeOriginalFileOnUpgrade: true,
                 openInTextEditor: false,
-                upgradeSarifOptions: (openLogFileArguments?.promptForUpgrade !== undefined) ? (openLogFileArguments?.promptForUpgrade ? 'Prompt' : 'Temporary') : undefined
+                upgradeSarifOptions: (openLogFileArguments?.promptForUpgrade !== undefined) ? (openLogFileArguments?.promptForUpgrade ? 'Prompt' : 'Always') : undefined
             });
         }
     }

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -222,7 +222,7 @@ export class FileConverter {
     public static async upgradeSarif(sarifFile: vscode.Uri, sarifVersion: SarifVersion | undefined, sarifSchemaVersion: SarifVersion | undefined, upgradeOptions?: UpgradeSarifOptions): Promise<vscode.Uri | undefined> {
         const desiredUpgradeOption: UpgradeSarifOptions = upgradeOptions ?? vscode.workspace.getConfiguration(Utilities.configSection).get(FileConverter.UpgradePromptSettingName, DefaultUpgradeOption);
 
-        if (desiredUpgradeOption === 'Prompt') {
+        if (desiredUpgradeOption !== 'Always') {
             const upgradeMessage: string = sarifSchemaVersion ?
              localize('converterTool.Upgrade.AskWithSchema', "Sarif schema version {0} is not supported. Upgrade to the latest schema version {1}?", sarifSchemaVersion.original, FileConverter.MultiToolCurrentSchemaVersion.original) :
              localize('converterTool.Upgrade.AskWithVersion', "Sarif version {0} is not supported. Upgrade to the latest version {1}?",

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -42,7 +42,7 @@ export interface UpgradeCheckInformation {
 /**
  * Options used during upgrade of SARIF to later schema version.
  */
-export type UpgradeSarifOptions = 'Prompt' | 'Temporary';
+export type UpgradeSarifOptions = 'Prompt' | 'Always';
 export const DefaultUpgradeOption: UpgradeSarifOptions = 'Prompt';
 
 /**
@@ -229,11 +229,11 @@ export class FileConverter {
                     sarifVersion && sarifVersion.original ? sarifVersion.original : localize('converterTool.Upgrade.UnknownVersion', "Unknown"), FileConverter.MultiToolCurrentSchemaVersion.original);
 
             const upgradeMessageItem: vscode.MessageItem = {
-                title: localize('converterTool.Upgrade.Upgrade', "Upgrade")
+                title: localize('converterTool.Upgrade.Once', "Once")
             };
 
             const neverShowAgainMessageItem: vscode.MessageItem = {
-                title: localize('converterTool.Upgrade.NeverShow', "Don't Show Again")
+                title: localize('converterTool.Upgrade.Always', "Alway")
             };
 
             const choice: vscode.MessageItem | undefined = await vscode.window.showInformationMessage(

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -10,6 +10,7 @@ import { ChildProcess, spawn } from "child_process";
 import multitoolPath from "@microsoft/sarif-multitool";
 
 import * as nls from 'vscode-nls';
+import { ConfigurationTarget } from "vscode";
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export interface UpgradeCheckInformation {
@@ -42,17 +43,15 @@ export interface UpgradeCheckInformation {
 /**
  * Options used during upgrade of SARIF to later schema version.
  */
-export interface UpgradeSarifOptions {
-    /**
-     * Indicates whether or not to prompt the user. If prompt user is 'no' a temp file will be created.
-     */
-    promptUserForUpgrade: boolean;
-}
+export type UpgradeSarifOptions = 'Prompt' | 'In Place' | 'Temporary';
+export const DefaultUpgradeOption : UpgradeSarifOptions = 'Prompt';
 
 /**
  * Handles converting a non sarif static analysis file to a sarif file via the sarif-sdk multitool
  */
 export class FileConverter {
+    private static readonly UpgradePromptSettingName: string = 'logUpgrade.prompt';
+
     public static initialize(extensionContext: vscode.ExtensionContext): void {
         FileConverter.registerCommands(extensionContext);
     }
@@ -219,67 +218,40 @@ export class FileConverter {
      * @param sarifFile the text document of the sarif file to convert
      * @param sarifVersion version of the sarif log
      * @param sarifSchemaVersion version of the sarif logs schema
-     * @param options Indicates whether or not to prompt the user. If prompt user is 'no' a temp file will be created.
+     * @param upgradeOptions Controls how the user is prompted for SARIF log upgrades.
      */
-    public static async upgradeSarif(sarifFile: vscode.Uri, sarifVersion: SarifVersion | undefined, sarifSchemaVersion: SarifVersion | undefined, options: UpgradeSarifOptions): Promise<vscode.Uri | undefined> {
+    public static async upgradeSarif(sarifFile: vscode.Uri, sarifVersion: SarifVersion | undefined, sarifSchemaVersion: SarifVersion | undefined, upgradeOptions?: UpgradeSarifOptions): Promise<vscode.Uri | undefined> {
+        const desiredUpgradeOption : UpgradeSarifOptions = upgradeOptions ?? vscode.workspace.getConfiguration(Utilities.configSection).get(FileConverter.UpgradePromptSettingName, DefaultUpgradeOption);
 
-        const saveTempChoice: vscode.MessageItem = {
-            title: localize('converterTool.Upgrade.SaveTemp', "Yes (Save Temp)")
-        };
-
-        const saveAsChoice: vscode.MessageItem = {
-            title: localize('converterTool.Upgrade.SaveAs', "Yes (Save As)")
-        };
-
-        const noChoice: vscode.MessageItem = {
-            title: localize('converterTool.Upgrade.No', "No")
-        };
-
-        let choice: vscode.MessageItem | undefined;
-
-        if (options.promptUserForUpgrade) {
-            let upgradeMessage: string;
-
-            if (sarifSchemaVersion) {
-                upgradeMessage = localize('converterTool.Upgrade.AskWithSchema', "Sarif schema version {0} is not supported. Upgrade to the latest schema version {1}?", sarifSchemaVersion.original, FileConverter.MultiToolCurrentSchemaVersion.original);
-            } else {
-                upgradeMessage = localize('converterTool.Upgrade.AskWithVersion', "Sarif version {0} is not supported. Upgrade to the latest version {1}?",
+        if (desiredUpgradeOption === 'Prompt') {
+            const upgradeMessage: string = sarifSchemaVersion ?
+             localize('converterTool.Upgrade.AskWithSchema', "Sarif schema version {0} is not supported. Upgrade to the latest schema version {1}?", sarifSchemaVersion.original, FileConverter.MultiToolCurrentSchemaVersion.original) :
+             localize('converterTool.Upgrade.AskWithVersion', "Sarif version {0} is not supported. Upgrade to the latest version {1}?",
                     sarifVersion && sarifVersion.original ? sarifVersion.original : localize('converterTool.Upgrade.UnknownVersion', "Unknown"), FileConverter.MultiToolCurrentSchemaVersion.original);
-            }
 
-            choice = await vscode.window.showInformationMessage(
+            const upgradeMessageItem: vscode.MessageItem = {
+                title: localize('converterTool.Upgrade.Upgrade', "Upgrade")
+            };
+    
+            const neverShowAgainMessageItem: vscode.MessageItem = {
+                title: localize('converterTool.Upgrade.NeverShow', "Don't Show Again")
+            };
+
+            const choice: vscode.MessageItem | undefined = await vscode.window.showInformationMessage(
                 upgradeMessage,
                 { modal: false },
-                saveTempChoice, saveAsChoice, noChoice);
+                upgradeMessageItem, neverShowAgainMessageItem);
 
-            if (!choice || choice === noChoice) {
+            if (!choice) {
                 return undefined;
             }
-        } else {
-            choice = saveTempChoice;
+            
+            if (choice === neverShowAgainMessageItem) {
+                await vscode.workspace.getConfiguration(Utilities.configSection).update(FileConverter.UpgradePromptSettingName, <UpgradeSarifOptions>'Temporary', ConfigurationTarget.Global);
+            }
         }
 
-        let output: string | undefined;
-        switch (choice) {
-            case saveTempChoice:
-                output = Utilities.generateTempPath(sarifFile.fsPath);
-                break;
-
-            case saveAsChoice:
-                const selectedUri: vscode.Uri | undefined = await vscode.window.showSaveDialog({
-                    defaultUri: sarifFile,
-                    filters: { sarif: ['sarif'] }
-                });
-
-                if (selectedUri) {
-                    output = selectedUri.fsPath;
-                }
-                break;
-        }
-
-        if (!output) {
-            return undefined;
-        }
+        const output: string =  Utilities.generateTempPath(sarifFile.fsPath);
 
         const fileOutputPath: string = output;
         const errorData: string[] = [];

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -43,7 +43,7 @@ export interface UpgradeCheckInformation {
 /**
  * Options used during upgrade of SARIF to later schema version.
  */
-export type UpgradeSarifOptions = 'Prompt' | 'In Place' | 'Temporary';
+export type UpgradeSarifOptions = 'Prompt' | 'Temporary';
 export const DefaultUpgradeOption : UpgradeSarifOptions = 'Prompt';
 
 /**

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -228,25 +228,25 @@ export class FileConverter {
              localize('converterTool.Upgrade.AskWithVersion', "Sarif version {0} is not supported. Upgrade to the latest version {1}?",
                     sarifVersion && sarifVersion.original ? sarifVersion.original : localize('converterTool.Upgrade.UnknownVersion', "Unknown"), FileConverter.MultiToolCurrentSchemaVersion.original);
 
-            const upgradeMessageItem: vscode.MessageItem = {
+            const upgradeOnceMessageItem: vscode.MessageItem = {
                 title: localize('converterTool.Upgrade.Once', "Once")
             };
 
-            const neverShowAgainMessageItem: vscode.MessageItem = {
+            const upgradeAlwaysMessageItem: vscode.MessageItem = {
                 title: localize('converterTool.Upgrade.Always', "Alway")
             };
 
             const choice: vscode.MessageItem | undefined = await vscode.window.showInformationMessage(
                 upgradeMessage,
                 { modal: false },
-                upgradeMessageItem, neverShowAgainMessageItem);
+                upgradeOnceMessageItem, upgradeAlwaysMessageItem);
 
             if (!choice) {
                 return undefined;
             }
 
-            if (choice === neverShowAgainMessageItem) {
-                await vscode.workspace.getConfiguration(Utilities.configSection).update(FileConverter.UpgradePromptSettingName, <UpgradeSarifOptions>'Temporary', vscode.ConfigurationTarget.Global);
+            if (choice === upgradeAlwaysMessageItem) {
+                await vscode.workspace.getConfiguration(Utilities.configSection).update(FileConverter.UpgradePromptSettingName, < UpgradeSarifOptions>'Always', vscode.ConfigurationTarget.Global);
             }
         }
 

--- a/src/fileConverter.ts
+++ b/src/fileConverter.ts
@@ -10,7 +10,6 @@ import { ChildProcess, spawn } from "child_process";
 import multitoolPath from "@microsoft/sarif-multitool";
 
 import * as nls from 'vscode-nls';
-import { ConfigurationTarget } from "vscode";
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export interface UpgradeCheckInformation {
@@ -44,7 +43,7 @@ export interface UpgradeCheckInformation {
  * Options used during upgrade of SARIF to later schema version.
  */
 export type UpgradeSarifOptions = 'Prompt' | 'Temporary';
-export const DefaultUpgradeOption : UpgradeSarifOptions = 'Prompt';
+export const DefaultUpgradeOption: UpgradeSarifOptions = 'Prompt';
 
 /**
  * Handles converting a non sarif static analysis file to a sarif file via the sarif-sdk multitool
@@ -221,7 +220,7 @@ export class FileConverter {
      * @param upgradeOptions Controls how the user is prompted for SARIF log upgrades.
      */
     public static async upgradeSarif(sarifFile: vscode.Uri, sarifVersion: SarifVersion | undefined, sarifSchemaVersion: SarifVersion | undefined, upgradeOptions?: UpgradeSarifOptions): Promise<vscode.Uri | undefined> {
-        const desiredUpgradeOption : UpgradeSarifOptions = upgradeOptions ?? vscode.workspace.getConfiguration(Utilities.configSection).get(FileConverter.UpgradePromptSettingName, DefaultUpgradeOption);
+        const desiredUpgradeOption: UpgradeSarifOptions = upgradeOptions ?? vscode.workspace.getConfiguration(Utilities.configSection).get(FileConverter.UpgradePromptSettingName, DefaultUpgradeOption);
 
         if (desiredUpgradeOption === 'Prompt') {
             const upgradeMessage: string = sarifSchemaVersion ?
@@ -232,7 +231,7 @@ export class FileConverter {
             const upgradeMessageItem: vscode.MessageItem = {
                 title: localize('converterTool.Upgrade.Upgrade', "Upgrade")
             };
-    
+
             const neverShowAgainMessageItem: vscode.MessageItem = {
                 title: localize('converterTool.Upgrade.NeverShow', "Don't Show Again")
             };
@@ -245,9 +244,9 @@ export class FileConverter {
             if (!choice) {
                 return undefined;
             }
-            
+
             if (choice === neverShowAgainMessageItem) {
-                await vscode.workspace.getConfiguration(Utilities.configSection).update(FileConverter.UpgradePromptSettingName, <UpgradeSarifOptions>'Temporary', ConfigurationTarget.Global);
+                await vscode.workspace.getConfiguration(Utilities.configSection).update(FileConverter.UpgradePromptSettingName, <UpgradeSarifOptions>'Temporary', vscode.ConfigurationTarget.Global);
             }
         }
 


### PR DESCRIPTION
The PR addresses issue #261 
Add a configuration that allows the user to effectively disable the upgrade prompt and have SARIF files that need to be upgraded done so automatically as a temporary file.

@jeffersonking and I have been discussing that there are at least two types of consumers of the SARIF viewer, there are SARIF producers and SARIF consumers. In the case where you are a SARIF producer, seeing the prompt is nice because it gives you and indication that the SARIF producer is out of date. As a consumer, well, you would probably always want to update.

For the time being, we have consumers that will always want an automatic upgrade any out of date SARIF logs,

So the behavior of this change is as follows:
The existing behavior remains where a user is "Prompted" for upgrade. They have options [Upgrade] or [Don't show me this again]. If the users chooses "either" of these options, a temporary file is created. In the case of "Don't show me this again", a configuration is updated to suppress the prompts and always create a temporary file. Clicking the "X" or pressing escape cancels the upgrade\open flow applying no changes. 

The option for "Save As" was removed, because, well, if you want to save the converted file, just use File\Save AS from VSCode.