### PR TITLE
API Enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,31 +31,31 @@
             }
         },
         "@microsoft/sarif-multitool": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool/-/sarif-multitool-2.2.3.tgz",
-            "integrity": "sha512-5CIfoT8iArzFS3V66bPHNstIxdPk23bZGTu6kDsspH6MLeEAZ+riQ7uJQqdIVEBvFkqJKLrEnRWF6rYzEvz6XQ==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool/-/sarif-multitool-2.2.4.tgz",
+            "integrity": "sha512-j0/JAS5ovmaYiJ9gb4VFvWKfp+rcHVqc4oNEnJtGpEAeK6g3ecG52icQ3JAXbfG2vUNwrQgWKyOb2O1fpjzzag==",
             "requires": {
-                "@microsoft/sarif-multitool-darwin": "^2.2.3",
-                "@microsoft/sarif-multitool-linux": "^2.2.3",
-                "@microsoft/sarif-multitool-win32": "^2.2.3"
+                "@microsoft/sarif-multitool-darwin": "^2.2.4",
+                "@microsoft/sarif-multitool-linux": "^2.2.4",
+                "@microsoft/sarif-multitool-win32": "^2.2.4"
             }
         },
         "@microsoft/sarif-multitool-darwin": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-darwin/-/sarif-multitool-darwin-2.2.3.tgz",
-            "integrity": "sha512-6y3zTVX4qO4w+l/SfSkQaWQuPoUeWE4zykKTNTFLCimudjCsRWE0O4bzbXRbBM1zgG/cbqBBQuvmoaxUOS3iVg==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-darwin/-/sarif-multitool-darwin-2.2.4.tgz",
+            "integrity": "sha512-L08qh5Zz/Nt2TijFSBcQ6ay1vK9W/kNTlpeAhOGIRAYaZE3Fu9epTCzklHyAmd+ZyDdTjPQjPFSMIF3yh1uhHQ==",
             "optional": true
         },
         "@microsoft/sarif-multitool-linux": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-linux/-/sarif-multitool-linux-2.2.3.tgz",
-            "integrity": "sha512-2dU5w7sdvJBFAkCJ9lghEShWEJeSDRFkpC1tul4f2yYVpw8mGBUHyfvxrO0hingiUggAfh0Wt/yXW1YVUjKH6w==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-linux/-/sarif-multitool-linux-2.2.4.tgz",
+            "integrity": "sha512-w2G1hD5U9n6TxIjJelUcX9W+F3lAvDJPYvKU4nATkXvxZCX6zgOXkNS1hLAhOeGLYGWDD1a+S8P4+jHgtt6biQ==",
             "optional": true
         },
         "@microsoft/sarif-multitool-win32": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-win32/-/sarif-multitool-win32-2.2.3.tgz",
-            "integrity": "sha512-0CColCvCWvZ6IVq9KSsdhf9tyDmTX/q4fZGoErSluYDHtz1RI3KZFkwfHvq65wlK3FLd2kISQY/cm/kLvmkTFg==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-win32/-/sarif-multitool-win32-2.2.4.tgz",
+            "integrity": "sha512-02m+Hh0gj5rRxeciPez6dDoiAQ3eY5uta/ky91Z/lE9LLLNM1Q7ZO7NjNjUqLc2u+nlVctlQoCAAn8vKas+75w==",
             "optional": true
         },
         "@types/events": {

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
             "properties": {
                 "sarif-viewer.rootpaths": {
                     "type": "array",
-                    "default": [
-                        "c:\\sample\\path"
-                    ],
                     "description": "%configuration.sarif-viewer.rootpaths.description%"
                 },
                 "sarif-viewer.resultsListHideColumns": {

--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
     },
     "dependencies": {
         "semver": "^7.3.2",
-        "@microsoft/sarif-multitool": "^2.2.3",
+        "@microsoft/sarif-multitool": "^2.2.4",
         "json-source-map": "^0.4.0",
         "jsonpointer": "4.0.1",
         "markdown-it": "^9.0.1",

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -46,7 +46,7 @@ export interface Api {
     closeAllLogs(): Promise<void>;
 
     /**
-     * A set of base URIs to use for mapping remote artifact locations.
+     * A set of URIs bases to use for mapping remote artifact locations.
      */
-    baseUris: ReadonlyArray<vscode.Uri>;
+    uriBases: ReadonlyArray<vscode.Uri>;
 }

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -20,13 +20,6 @@ export interface OpenLogArguments {
      * The default is true.
      */
     readonly openViewerWhenNoResults?: boolean;
-
-    /**
-     * A set of root paths to use for mapping remote artifact locations.
-     * The paths are used only for this instance of the extension.
-     * They are not persisted in the user settings.
-     */
-    readonly localRootPaths?: vscode.Uri[];
 }
 
 /**
@@ -53,9 +46,7 @@ export interface Api {
     closeAllLogs(): Promise<void>;
 
     /**
-     * A set of root paths to use for mapping remote artifact locations.
-     * The paths are used only for this instance of the extension.
-     * They are not persisted in the user settings.
+     * A set of base URIs to use for mapping remote artifact locations.
      */
-    rootPaths: vscode.Uri[];
+    baseUris: ReadonlyArray<vscode.Uri>;
 }

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -23,8 +23,8 @@ export interface OpenLogArguments {
 
     /**
      * A set of root paths to use for mapping remote artifact locations.
-     * The paths are used only for this instance
-     * of the extension and are note persisted in the user settings.
+     * The paths are used only for this instance of the extension.
+     * They are not persisted in the user settings.
      */
     readonly localRootPaths?: vscode.Uri[];
 }
@@ -54,8 +54,8 @@ export interface Api {
 
     /**
      * A set of root paths to use for mapping remote artifact locations.
-     * The paths are used only for this instance
-     * of the extension and are note persisted in the user settings.
+     * The paths are used only for this instance of the extension.
+     * They are not persisted in the user settings.
      */
     rootPaths: vscode.Uri[];
 }

--- a/src/api/sarifViewerApi.ts
+++ b/src/api/sarifViewerApi.ts
@@ -20,6 +20,13 @@ export interface OpenLogArguments {
      * The default is true.
      */
     readonly openViewerWhenNoResults?: boolean;
+
+    /**
+     * A set of root paths to use for mapping remote artifact locations.
+     * The paths are used only for this instance
+     * of the extension and are note persisted in the user settings.
+     */
+    readonly localRootPaths?: vscode.Uri[];
 }
 
 /**
@@ -27,11 +34,12 @@ export interface OpenLogArguments {
  */
 export interface Api {
     /**
-     * Opens logs .
+     * Opens logs.
      * @param logs The logs to open.
      * @param openLogArguments Parameters that control how the logs are opened.
+     * @param cancellationToken Token used to cancel the open log request.
      */
-    openLogs(logs: vscode.Uri[], openLogArguments?: OpenLogArguments): Promise<void>;
+    openLogs(logs: vscode.Uri[], openLogArguments?: OpenLogArguments, cancellationToken?: vscode.CancellationToken): Promise<void>;
 
     /**
      * Closes logs.
@@ -43,4 +51,11 @@ export interface Api {
      * Closes all logs.
      */
     closeAllLogs(): Promise<void>;
+
+    /**
+     * A set of root paths to use for mapping remote artifact locations.
+     * The paths are used only for this instance
+     * of the extension and are note persisted in the user settings.
+     */
+    rootPaths: vscode.Uri[];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,14 +289,14 @@ class SarifExtension implements Api {
      * @inheritdoc
      */
     public get baseUris(): ReadonlyArray<vscode.Uri> {
-        return FileMapper.InitializeFileMapper().rootPathsFromApi;
+        return FileMapper.InitializeFileMapper().baseUrisFromApi;
     }
 
     /**
      * @inheritdoc
      */
     public set baseUris(localRootPaths: ReadonlyArray<vscode.Uri>) {
-        FileMapper.InitializeFileMapper().rootPathsFromApi = localRootPaths;
+        FileMapper.InitializeFileMapper().baseUrisFromApi = localRootPaths;
     }
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,10 +235,6 @@ class SarifExtension implements Api {
      * @inheritdoc
      */
     public async openLogs(logs: vscode.Uri[], openLogFileArguments?: OpenLogArguments, cancellationToken?: vscode.CancellationToken): Promise<void> {
-        if (openLogFileArguments?.localRootPaths) {
-            FileMapper.InitializeFileMapper().rootPathsFromApi = openLogFileArguments?.localRootPaths;
-        }
-
         for (const log of logs) {
             if (cancellationToken?.isCancellationRequested) {
                 return;
@@ -292,14 +288,14 @@ class SarifExtension implements Api {
     /**
      * @inheritdoc
      */
-    public get rootPaths(): vscode.Uri[] {
+    public get baseUris(): ReadonlyArray<vscode.Uri> {
         return FileMapper.InitializeFileMapper().rootPathsFromApi;
     }
 
     /**
      * @inheritdoc
      */
-    public set rootPaths(localRootPaths: vscode.Uri[]) {
+    public set baseUris(localRootPaths: ReadonlyArray<vscode.Uri>) {
         FileMapper.InitializeFileMapper().rootPathsFromApi = localRootPaths;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -265,7 +265,7 @@ class SarifExtension implements Api {
             if (log.isSarifFile()) {
                 logsToClose.push(log);
                 /***
-                 * The temp file path name generated is always results the same output
+                 * Utilities.generateTempPath always generates the same output path
                  * for the same input path.
                  * Note that there is no need to check for existence of the file here
                  * because it is only being used as a key for parsed results in the viewer.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -288,15 +288,15 @@ class SarifExtension implements Api {
     /**
      * @inheritdoc
      */
-    public get baseUris(): ReadonlyArray<vscode.Uri> {
-        return FileMapper.InitializeFileMapper().baseUrisFromApi;
+    public get uriBases(): ReadonlyArray<vscode.Uri> {
+        return FileMapper.InitializeFileMapper().uriBasesFromApi;
     }
 
     /**
      * @inheritdoc
      */
-    public set baseUris(localRootPaths: ReadonlyArray<vscode.Uri>) {
-        FileMapper.InitializeFileMapper().baseUrisFromApi = localRootPaths;
+    public set uriBases(localRootPaths: ReadonlyArray<vscode.Uri>) {
+        FileMapper.InitializeFileMapper().uriBasesFromApi = localRootPaths;
     }
 
     /**

--- a/src/fileMapper.ts
+++ b/src/fileMapper.ts
@@ -46,12 +46,12 @@ export class FileMapper implements Disposable {
      * Contains the root paths configured in the settings by the user or
      * paths automatically added when the user uses the remap UI flow.
      */
-    private baseUrisFromUserSettings: Uri[] = [];
+    private uriBasesFromUserSettings: Uri[] = [];
 
     /**
      * Contains the set of root paths set by our extension's APIs.
      */
-    private baseUrisSetByApi: Uri[] = [];
+    private uriBasesSetByApi: Uri[] = [];
 
     private constructor() {
         if (FileMapper.fileMapperInstance) {
@@ -67,25 +67,25 @@ export class FileMapper implements Disposable {
     /**
      * Gets the root paths to use for mapping remote artifact locations.
      */
-    public get baseUrisFromApi(): ReadonlyArray<Uri> {
-        return this.baseUrisSetByApi;
+    public get uriBasesFromApi(): ReadonlyArray<Uri> {
+        return this.uriBasesSetByApi;
     }
 
     /**
      * Sets the root paths to use for mapping remote artifact locations.
      */
-    public set baseUrisFromApi(baseUris: ReadonlyArray<Uri>) {
-        this.baseUrisSetByApi = baseUris.map((baseUri) => {
-            if (!baseUri.isFile()) {
+    public set uriBasesFromApi(uriBases: ReadonlyArray<Uri>) {
+        this.uriBasesSetByApi = uriBases.map((uriBase) => {
+            if (!uriBase.isFile()) {
                 throw new Error(localize('fileMapper.localPathMustBeFile', "The local path ({0}) must have a file scheme."));
             }
 
-            return baseUri;
+            return uriBase;
         });
     }
 
     private get allRootPaths(): ReadonlyArray<Uri>  {
-        return this.baseUrisFromUserSettings.concat(this.baseUrisSetByApi);
+        return this.uriBasesFromUserSettings.concat(this.uriBasesSetByApi);
     }
 
     /**
@@ -261,7 +261,7 @@ export class FileMapper implements Disposable {
                 if (this.isLocalDirectory(validateUri)) {
                     const foundRootPath: Uri | undefined = this.allRootPaths.find((rootPath) => validateUri && rootPath.fsPath.invariantEqual(validateUri.fsPath));
                     if (!foundRootPath) {
-                        this.baseUrisFromUserSettings.push(validateUri);
+                        this.uriBasesFromUserSettings.push(validateUri);
                     }
                 }
 
@@ -426,7 +426,7 @@ export class FileMapper implements Disposable {
             const sarifConfig: WorkspaceConfiguration = workspace.getConfiguration(Utilities.configSection);
             const newRootPaths: string [] = sarifConfig.get(ConfigRootPaths, []);
 
-            if (this.baseUrisFromUserSettings.sort().toString() !== newRootPaths.sort().toString()) {
+            if (this.uriBasesFromUserSettings.sort().toString() !== newRootPaths.sort().toString()) {
                 const newRootPathsAsUris: Uri[] = [];
                 for (const newRootPath of newRootPaths) {
                     try {
@@ -435,7 +435,7 @@ export class FileMapper implements Disposable {
                         // Consider logging to output pane here?
                     }
                 }
-                this.baseUrisFromUserSettings = newRootPathsAsUris;
+                this.uriBasesFromUserSettings = newRootPathsAsUris;
                 this.updateMappingsWithRootPaths();
             }
         }

--- a/src/fileMapper.ts
+++ b/src/fileMapper.ts
@@ -387,7 +387,7 @@ export class FileMapper implements Disposable {
     /**
      * Tries to remapped path using any of the RootPaths in the config
      */
-    private tryConfigRootPathsUri(originUri: Uri, uriBase?: string, ...rootPaths: Uri[]): Uri | undefined {
+    private tryConfigRootPathsUri(originUri: Uri, uriBase: string | undefined, ...rootPaths: Uri[]): Uri | undefined {
         // Parse the remote URI into directory parts.
         const originPath: path.ParsedPath = path.parse(originUri.fsPath);
 
@@ -395,7 +395,7 @@ export class FileMapper implements Disposable {
         // So given an incoming URI such as "e:\foo\bar\xyz.cpp" we are left with "\foo\bar"
         const originPathWithoutRoot: string = path.join(originPath.dir.replace(originPath.root, ''), originPath.base);
 
-        for (const rootPath of rootPaths ?? this.allRootPaths) {
+        for (const rootPath of (rootPaths.length !== 0 ? rootPaths : this.allRootPaths)) {
             const dirParts: string[] = originPathWithoutRoot.split(path.sep);
 
             // This logic simply adds the prepends the passed in root path(s) to the directory

--- a/src/fileMapper.ts
+++ b/src/fileMapper.ts
@@ -46,12 +46,12 @@ export class FileMapper implements Disposable {
      * Contains the root paths configured in the settings by the user or
      * paths automatically added when the user uses the remap UI flow.
      */
-    private rootPathsFromUserSettings: Uri[] = [];
+    private baseUrisFromUserSettings: Uri[] = [];
 
     /**
      * Contains the set of root paths set by our extension's APIs.
      */
-    private rootPathsSetByApi: Uri[] = [];
+    private baseUrisSetByApi: Uri[] = [];
 
     private constructor() {
         if (FileMapper.fileMapperInstance) {
@@ -67,25 +67,25 @@ export class FileMapper implements Disposable {
     /**
      * Gets the root paths to use for mapping remote artifact locations.
      */
-    public get rootPathsFromApi(): Uri[] {
-        return this.rootPathsSetByApi;
+    public get baseUrisFromApi(): ReadonlyArray<Uri> {
+        return this.baseUrisSetByApi;
     }
 
     /**
      * Sets the root paths to use for mapping remote artifact locations.
      */
-    public set rootPathsFromApi(localRootPaths: Uri[]) {
-        this.rootPathsSetByApi = localRootPaths.map((localRootPath) => {
-            if (!localRootPath.isFile()) {
+    public set baseUrisFromApi(baseUris: ReadonlyArray<Uri>) {
+        this.baseUrisSetByApi = baseUris.map((baseUri) => {
+            if (!baseUri.isFile()) {
                 throw new Error(localize('fileMapper.localPathMustBeFile', "The local path ({0}) must have a file scheme."));
             }
 
-            return localRootPath;
+            return baseUri;
         });
     }
 
-    private get allRootPaths(): Uri [] {
-        return this.rootPathsFromUserSettings.concat(this.rootPathsSetByApi);
+    private get allRootPaths(): ReadonlyArray<Uri>  {
+        return this.baseUrisFromUserSettings.concat(this.baseUrisSetByApi);
     }
 
     /**
@@ -261,7 +261,7 @@ export class FileMapper implements Disposable {
                 if (this.isLocalDirectory(validateUri)) {
                     const foundRootPath: Uri | undefined = this.allRootPaths.find((rootPath) => validateUri && rootPath.fsPath.invariantEqual(validateUri.fsPath));
                     if (!foundRootPath) {
-                        this.rootPathsFromUserSettings.push(validateUri);
+                        this.baseUrisFromUserSettings.push(validateUri);
                     }
                 }
 
@@ -426,7 +426,7 @@ export class FileMapper implements Disposable {
             const sarifConfig: WorkspaceConfiguration = workspace.getConfiguration(Utilities.configSection);
             const newRootPaths: string [] = sarifConfig.get(ConfigRootPaths, []);
 
-            if (this.rootPathsFromUserSettings.sort().toString() !== newRootPaths.sort().toString()) {
+            if (this.baseUrisFromUserSettings.sort().toString() !== newRootPaths.sort().toString()) {
                 const newRootPathsAsUris: Uri[] = [];
                 for (const newRootPath of newRootPaths) {
                     try {
@@ -435,7 +435,7 @@ export class FileMapper implements Disposable {
                         // Consider logging to output pane here?
                     }
                 }
-                this.rootPathsFromUserSettings = newRootPathsAsUris;
+                this.baseUrisFromUserSettings = newRootPathsAsUris;
                 this.updateMappingsWithRootPaths();
             }
         }

--- a/src/fileMapper.ts
+++ b/src/fileMapper.ts
@@ -190,6 +190,7 @@ export class FileMapper implements Disposable {
     /**
      * Shows the input box with message for getting the user to select the mapping
      * @param uri uri of the file that needs to be mapped
+     * @param uriBase A URI base to use for the mapping if known.
      */
     private async openRemappingInputDialog(uri: Uri, uriBase?: string): Promise<string | undefined> {
         interface RemappingQuickInputButtons extends QuickInputButton {
@@ -252,7 +253,7 @@ export class FileMapper implements Disposable {
                     return;
                 }
 
-                const remappedUri: Uri | undefined = this.tryConfigRootPathsUri(uri, uriBase, [validateUri]);
+                const remappedUri: Uri | undefined = this.tryConfigRootPathsUri(uri, uriBase, validateUri);
                 if (!remappedUri) {
                     return;
                 }
@@ -386,7 +387,7 @@ export class FileMapper implements Disposable {
     /**
      * Tries to remapped path using any of the RootPaths in the config
      */
-    private tryConfigRootPathsUri(originUri: Uri, uriBase?: string, rootPaths?: Uri[]): Uri | undefined {
+    private tryConfigRootPathsUri(originUri: Uri, uriBase?: string, ...rootPaths: Uri[]): Uri | undefined {
         // Parse the remote URI into directory parts.
         const originPath: path.ParsedPath = path.parse(originUri.fsPath);
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -183,14 +183,11 @@ export class Utilities {
      */
     public static generateTempPath(filePath: string): string {
         const pathObj: path.ParsedPath = path.parse(filePath);
-        let basePath: string = path.join(Utilities.SarifViewerTempDir, '');
         let tempPath: string = Utilities.makeFileNameSafe(
             path.join(pathObj.dir.replace(pathObj.root, ''), path.basename(filePath)));
         tempPath = tempPath.split('#').join(''); // remove the #s to not create a folder structure with fragments
-        basePath = Utilities.createDirectoryInTemp(basePath);
-        tempPath = path.join(basePath, tempPath);
-
-        return tempPath;
+        const basePath: string = Utilities.createDirectoryInTemp(Utilities.SarifViewerTempDir);
+        return path.join(basePath, tempPath);
     }
 
     /**

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -177,15 +177,15 @@ export class Utilities {
     }
 
     /**
-     * Generates a folder path matching original path in the temp location and returns the path with the file included
+     * Generates a folder path matching original path in the temp location and returns the path with the file included.
+     * The function will always return the same output for the same given input.
      * @param filePath original file path, to recreate in the temp location
-     * @param hashValue optional hash value to add to the path
      */
-    public static generateTempPath(filePath: string, hashValue?: string): string {
+    public static generateTempPath(filePath: string): string {
         const pathObj: path.ParsedPath = path.parse(filePath);
-        let basePath: string = path.join(Utilities.SarifViewerTempDir, hashValue || '');
+        let basePath: string = path.join(Utilities.SarifViewerTempDir, '');
         let tempPath: string = Utilities.makeFileNameSafe(
-            path.join(pathObj.dir.replace(pathObj.root, ''), path.win32.basename(filePath)));
+            path.join(pathObj.dir.replace(pathObj.root, ''), path.basename(filePath)));
         tempPath = tempPath.split('#').join(''); // remove the #s to not create a folder structure with fragments
         basePath = Utilities.createDirectoryInTemp(basePath);
         tempPath = path.join(basePath, tempPath);


### PR DESCRIPTION
This addresses issue #275.

When a log-file is upgraded to the latest schema version, the viewer loses track of the original file, so when the closeLogs API is called, it doesn't have anythning to remove from the viewer. I've made the cheapest fix for now which since we create the temp-files in the same location with the same name is the input file, when closeLog is called, I simply ask the viewer to close the temp file as well. It doesn't matter if it actually exists or not because it is only being used as a key.

The second change is to pass a cancellation token into the openLogs API to allow cancellation for a large number of logs files.

The third change is to allow consumers of the API to pass in root paths that they know about in the openLogFiles API as well as the ability to set the directly.

All unit tests passed and verification with another extension calling the API is in progress.