### PR TITLE
Fixes for issue #289, #290, #291

### DIFF
--- a/src/panel/Details.scss
+++ b/src/panel/Details.scss
@@ -13,6 +13,7 @@
 
             .svDetailsMessage {
                 margin-bottom: 16px;
+                white-space: pre-line;
             }
 
             .svDetailsGrid {
@@ -21,6 +22,7 @@
                 grid-column-gap: 4px;
                 grid-row-gap: 4px;
                 justify-items: start;
+                white-space: pre-line;
 
                 & > * {
                     display: grid;

--- a/src/panel/Details.scss
+++ b/src/panel/Details.scss
@@ -25,7 +25,6 @@
                 white-space: pre-line;
 
                 & > * {
-                    display: grid;
                     &:nth-child(odd) {
                         color: rgb(139, 139, 139); // svSecondary.
                     }

--- a/src/panel/ResultTable.tsx
+++ b/src/panel/ResultTable.tsx
@@ -28,7 +28,7 @@ interface ResultTableProps<G> {
         const customRenderers = {
             'File':     result => <span title={result._uri}>{result._uri?.file ?? '—'}</span>,
             'Line':     result => <span>{result._line < 0 ? '—' : result._line}</span>,
-            'Message':  result => <span>{renderMessageWithEmbeddedLinks(result, vscode.postMessage)}</span>,
+            'Message':  result => <span>{renderMessageWithEmbeddedLinks(result, vscode.postMessage, result._message)}</span>,
             'Rule':     result => <>
                 <span>{result._rule?.name ?? '—'}</span>
                 <span className="svSecondary">{result.ruleId}</span>

--- a/src/panel/ResultTable.tsx
+++ b/src/panel/ResultTable.tsx
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react';
 import * as React from 'react';
 import { PureComponent, ReactNode } from 'react';
 import { Result } from 'sarif';
-import { renderMessageWithEmbeddedLinks } from './widgets';
+import { renderMessageTextWithEmbeddedLinks } from './widgets';
 import { ResultTableStore } from './resultTableStore';
 import { Table } from './table';
 import { Column } from './tableStore';
@@ -28,7 +28,7 @@ interface ResultTableProps<G> {
         const customRenderers = {
             'File':     result => <span title={result._uri}>{result._uri?.file ?? '—'}</span>,
             'Line':     result => <span>{result._line < 0 ? '—' : result._line}</span>,
-            'Message':  result => <span>{renderMessageWithEmbeddedLinks(result, vscode.postMessage, result._message)}</span>,
+            'Message':  result => <span>{renderMessageTextWithEmbeddedLinks(result._message, result, vscode.postMessage)}</span>,
             'Rule':     result => <>
                 <span>{result._rule?.name ?? '—'}</span>
                 <span className="svSecondary">{result.ruleId}</span>

--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -11,7 +11,7 @@ import ReactMarkdown from 'react-markdown';
 import { Location, Result, StackFrame } from 'sarif';
 import { parseArtifactLocation, parseLocation } from '../shared';
 import './details.scss';
-import './index.scss'
+import './index.scss';
 import { postSelectArtifact, postSelectLog } from './indexStore';
 import { List, renderMessageWithEmbeddedLinks, Tab, TabPanel } from './widgets';
 
@@ -23,10 +23,10 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
     @computed private get threadFlowLocations() {
 		return this.props.result?.codeFlows?.[0]?.threadFlows?.[0].locations
 			.map(threadFlowLocation => threadFlowLocation.location)
-			.filter(locations => locations)
+			.filter(locations => locations);
 	}
     @computed private get stacks() {
-        return this.props.result?.stacks
+        return this.props.result?.stacks;
     }
     constructor(props: DetailsProps) {
         super(props);
@@ -36,34 +36,34 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
         });
     }
     render() {
-        const renderRuleDesc = (desc?: { text: string, markdown?: string }) => {
+        const renderRuleDesc = (result: Result, desc?: { text: string, markdown?: string }) => {
             if (!desc) return '—';
             return desc.markdown
-                ? <ReactMarkdown className="svMarkDown" source={desc.markdown} />
-                : desc.text;
+                ? <ReactMarkdown className="svMarkDown" source={desc.markdown} escapeHtml={false} />
+                : renderMessageWithEmbeddedLinks(result, vscode.postMessage, desc.text);
         };
 
         const {result, height} = this.props;
         const helpUri = result?._rule?.helpUri;
         const renderLocation = (location: Location) => {
-			const { message, uri, region } = parseLocation(result, location)
+			const { message, uri, region } = parseLocation(result, location);
 			return <>
 				<div className="ellipsis">{message ?? '—'}</div>
 				<div className="svSecondary">{uri?.file ?? '—'}</div>
 				<div className="svLineNum">{region?.startLine}:1</div>
-			</>
-		}
+			</>;
+		};
 		const renderStack = (stackFrame: StackFrame) => {
-			const location = stackFrame.location
-			const logicalLocation = stackFrame.location?.logicalLocations[0]
-			const { message, uri, region } = parseLocation(result, location)
-			const text = `${message ?? ''} ${logicalLocation?.fullyQualifiedName ?? ''}`
+			const location = stackFrame.location;
+			const logicalLocation = stackFrame.location?.logicalLocations[0];
+			const { message, uri, region } = parseLocation(result, location);
+			const text = `${message ?? ''} ${logicalLocation?.fullyQualifiedName ?? ''}`;
 			return <>
 				<div className="ellipsis">{text ?? '—'}</div>
 				<div className="svSecondary">{uri?.file ?? '—'}</div>
 				<div className="svLineNum">{region?.startLine}:1</div>
-			</>
-		}
+			</>;
+		};
         return <div className="svDetailsPane" style={{ height: height.get() }}>
             {result && <TabPanel selection={this.selectedTab}>
                 <Tab name="Info">
@@ -71,12 +71,12 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                         <div className="svDetailsMessage">
                             {result._markdown
                                 ? <ReactMarkdown className="svMarkDown" source={result._markdown} escapeHtml={false} />
-                                : renderMessageWithEmbeddedLinks(result, vscode.postMessage)}</div>
+                                : renderMessageWithEmbeddedLinks(result, vscode.postMessage, result._message)}</div>
                         <div className="svDetailsGrid">
                             <span>Rule Id</span>			{helpUri ? <a href={helpUri} target="_blank" rel="noopener noreferrer">{result.ruleId}</a> : <span>{result.ruleId}</span>}
                             <span>Rule Name</span>			<span>{result._rule?.name ?? '—'}</span>
-                            <span>Rule Desc Short</span>	<span>{renderRuleDesc(result._rule?.shortDescription)}</span>
-                            <span>Rule Desc Full</span>		<span>{renderRuleDesc(result._rule?.fullDescription)}</span>
+                            <span>Rule Desc Short</span>	<span><div>{renderRuleDesc(result, result._rule?.shortDescription)}</div></span>
+                            <span>Rule Desc Full</span>		<span><div>{renderRuleDesc(result, result._rule?.fullDescription)}</div></span>
                             <span>Level</span>				<span>{result.level}</span>
                             <span>Kind</span>				<span>{result.kind ?? '—'}</span>
                             <span>Baseline State</span>		<span>{result.baselineState}</span>
@@ -109,34 +109,34 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                         {(() => {
                             const items = this.threadFlowLocations;
 
-                            const selection = observable.box(undefined as Location, { deep: false })
+                            const selection = observable.box(undefined as unknown as Location, { deep: false });
                             selection.observe(change => {
-                                const location = change.newValue
-                                postSelectArtifact(result, location?.physicalLocation)
-                            })
+                                const location = change.newValue;
+                                postSelectArtifact(result, location?.physicalLocation);
+                            });
 
-                            return <List items={items} renderItem={renderLocation} selection={selection} allowClear>
+                            return <List items={items as ReadonlyArray<Location>} renderItem={renderLocation} selection={selection} allowClear>
                                 <span className="svSecondary">No code flows in selected result.</span>
-                            </List>
+                            </List>;
                         })()}
                     </div>
                 </Tab>
                 <Tab name="Stacks" count={this.stacks?.length || 0}>
                     <div className="svDetailsBody">
                         {(() => {
-                            if (!this.stacks?.length) 
+                            if (!this.stacks?.length)
                                 return <div className="svZeroData">
                                     <span className="svSecondary">No stacks in selected result.</span>
-                                </div>
+                                </div>;
 
                             return this.stacks.map(stack => {
-                                const stackFrames = stack.frames
+                                const stackFrames = stack.frames;
 
-                                const selection = observable.box(undefined as Location, { deep: false })
+                                const selection = observable.box(undefined as unknown as Location, { deep: false });
                                 selection.observe(change => {
-                                    const location = change.newValue
-                                    postSelectArtifact(result, location?.physicalLocation)
-                                })
+                                    const location = change.newValue;
+                                    postSelectArtifact(result, location?.physicalLocation);
+                                });
                                 if (stack.message?.text) {
                                     return <div className="svStack">
                                         <div className="svStacksMessage">
@@ -145,9 +145,9 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                                         <div className="svDetailsBody svDetailsCodeflowAndStacks">
                                             <List items={stackFrames} renderItem={renderStack} selection={selection} allowClear />
                                         </div>
-                                    </div>
+                                    </div>;
                                 }
-                            })
+                            });
                         })()}
                     </div>
                 </Tab>

--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -36,7 +36,8 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
         });
     }
     render() {
-        const renderRuleDesc = (result: Result, desc?: { text: string, markdown?: string }) => {
+        const renderRuleDesc = (result: Result) => {
+            const desc = result?._rule?.fullDescription ?? result?._rule?.shortDescription;
             if (!desc) return '—';
             return desc.markdown
                 ? <ReactMarkdown className="svMarkDown" source={desc.markdown} escapeHtml={false} />
@@ -75,8 +76,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                         <div className="svDetailsGrid">
                             <span>Rule Id</span>			{helpUri ? <a href={helpUri} target="_blank" rel="noopener noreferrer">{result.ruleId}</a> : <span>{result.ruleId}</span>}
                             <span>Rule Name</span>			<span>{result._rule?.name ?? '—'}</span>
-                            <span>Rule Desc Short</span>	<span><div>{renderRuleDesc(result, result._rule?.shortDescription)}</div></span>
-                            <span>Rule Desc Full</span>		<span><div>{renderRuleDesc(result, result._rule?.fullDescription)}</div></span>
+                            <span>Rule Description</span>	<span><div>{renderRuleDesc(result)}</div></span>
                             <span>Level</span>				<span>{result.level}</span>
                             <span>Kind</span>				<span>{result.kind ?? '—'}</span>
                             <span>Baseline State</span>		<span>{result.baselineState}</span>

--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -13,7 +13,7 @@ import { parseArtifactLocation, parseLocation } from '../shared';
 import './details.scss';
 import './index.scss';
 import { postSelectArtifact, postSelectLog } from './indexStore';
-import { List, renderMessageWithEmbeddedLinks, Tab, TabPanel } from './widgets';
+import { List, Tab, TabPanel, renderMessageTextWithEmbeddedLinks } from './widgets';
 
 type TabName = 'Info' | 'Code Flows';
 
@@ -41,7 +41,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
             if (!desc) return '—';
             return desc.markdown
                 ? <ReactMarkdown className="svMarkDown" source={desc.markdown} escapeHtml={false} />
-                : renderMessageWithEmbeddedLinks(result, vscode.postMessage, desc.text);
+                : renderMessageTextWithEmbeddedLinks(desc.text, result, vscode.postMessage);
         };
 
         const {result, height} = this.props;
@@ -72,11 +72,11 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                         <div className="svDetailsMessage">
                             {result._markdown
                                 ? <ReactMarkdown className="svMarkDown" source={result._markdown} escapeHtml={false} />
-                                : renderMessageWithEmbeddedLinks(result, vscode.postMessage, result._message)}</div>
+                                : renderMessageTextWithEmbeddedLinks(result._message, result, vscode.postMessage)}</div>
                         <div className="svDetailsGrid">
                             <span>Rule Id</span>			{helpUri ? <a href={helpUri} target="_blank" rel="noopener noreferrer">{result.ruleId}</a> : <span>{result.ruleId}</span>}
                             <span>Rule Name</span>			<span>{result._rule?.name ?? '—'}</span>
-                            <span>Rule Description</span>	<span><div>{renderRuleDesc(result)}</div></span>
+                            <span>Rule Description</span>	<span>{renderRuleDesc(result)}</span>
                             <span>Level</span>				<span>{result.level}</span>
                             <span>Kind</span>				<span>{result.kind ?? '—'}</span>
                             <span>Baseline State</span>		<span>{result.baselineState}</span>
@@ -109,7 +109,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                         {(() => {
                             const items = this.threadFlowLocations;
 
-                            const selection = observable.box(undefined as unknown as Location, { deep: false });
+                            const selection = observable.box<Location | undefined>(undefined, { deep: false });
                             selection.observe(change => {
                                 const location = change.newValue;
                                 postSelectArtifact(result, location?.physicalLocation);
@@ -132,7 +132,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                             return this.stacks.map(stack => {
                                 const stackFrames = stack.frames;
 
-                                const selection = observable.box(undefined as unknown as Location, { deep: false });
+                                const selection = observable.box<Location | undefined>(undefined, { deep: false });
                                 selection.observe(change => {
                                     const location = change.newValue;
                                     postSelectArtifact(result, location?.physicalLocation);

--- a/src/panel/widgets.tsx
+++ b/src/panel/widgets.tsx
@@ -252,11 +252,11 @@ export class ResizeHandle extends Component<{ size: IObservableValue<number>, ho
 // Borrowed from: sarif-web-component.
 // 3.11.6 Messages with embedded links. Replace [text](relatedIndex) with <a href />.
 // 3.10.3 sarif URI scheme is not supported.
-export function renderMessageWithEmbeddedLinks(result: Result, _postMessage: (_: unknown) => void, field?: string) {
-    if (field) {
+export function renderMessageTextWithEmbeddedLinks(text: string, result: Result, _postMessage: (_: unknown) => void ) {
+    if (text) {
         const rxLink = /\[([^\]]*)\]\(([^)]+)\)/; // Matches [text](id). Similar to below, but with an extra grouping around the id part.
-        return field.match(rxLink)
-            ? field
+        return text.match(rxLink)
+            ? text
                 .split(/(\[[^\]]*\]\([^)]+\))/g)
                 .map((item, i) => {
                     if (i % 2 === 0) return item;
@@ -269,6 +269,6 @@ export function renderMessageWithEmbeddedLinks(result: Result, _postMessage: (_:
                             postSelectArtifact(result, result?.relatedLocations?.find(rloc => rloc.id === +id)?.physicalLocation);
                         }}>{text}</a>;
                 })
-            : field;
+            : text;
     }
 }

--- a/src/panel/widgets.tsx
+++ b/src/panel/widgets.tsx
@@ -252,22 +252,23 @@ export class ResizeHandle extends Component<{ size: IObservableValue<number>, ho
 // Borrowed from: sarif-web-component.
 // 3.11.6 Messages with embedded links. Replace [text](relatedIndex) with <a href />.
 // 3.10.3 sarif URI scheme is not supported.
-export function renderMessageWithEmbeddedLinks(result: Result, _postMessage: (_: unknown) => void) {
-    const message = result._message;
-    const rxLink = /\[([^\]]*)\]\(([^)]+)\)/; // Matches [text](id). Similar to below, but with an extra grouping around the id part.
-    return message.match(rxLink)
-        ? message
-            .split(/(\[[^\]]*\]\([^)]+\))/g)
-            .map((item, i) => {
-                if (i % 2 === 0) return item;
-                const [_, text, id] = item.match(rxLink)!; // Safe since it was split by the same RegExp.
-                return isNaN(+id)
-                    ? <a key={i} tabIndex={-1} href={id}>{text}</a>
-                    : <a key={i} tabIndex={-1} href="#" onClick={e => {
-                        e.preventDefault(); // Don't leave a # in the url.
-                        e.stopPropagation();
-                        postSelectArtifact(result, result?.relatedLocations?.find(rloc => rloc.id === +id)?.physicalLocation);
-                    }}>{text}</a>;
-            })
-        : message;
+export function renderMessageWithEmbeddedLinks(result: Result, _postMessage: (_: unknown) => void, field?: string) {
+    if (field) {
+        const rxLink = /\[([^\]]*)\]\(([^)]+)\)/; // Matches [text](id). Similar to below, but with an extra grouping around the id part.
+        return field.match(rxLink)
+            ? field
+                .split(/(\[[^\]]*\]\([^)]+\))/g)
+                .map((item, i) => {
+                    if (i % 2 === 0) return item;
+                    const [_, text, id] = item.match(rxLink)!; // Safe since it was split by the same RegExp.
+                    return isNaN(+id)
+                        ? <a key={i} tabIndex={-1} href={id}>{text}</a>
+                        : <a key={i} tabIndex={-1} href="#" onClick={e => {
+                            e.preventDefault(); // Don't leave a # in the url.
+                            e.stopPropagation();
+                            postSelectArtifact(result, result?.relatedLocations?.find(rloc => rloc.id === +id)?.physicalLocation);
+                        }}>{text}</a>;
+                })
+            : field;
+    }
 }


### PR DESCRIPTION
#### Following fixes were made
- Links are rendered properly inside `Rule Description`
     ![image](https://user-images.githubusercontent.com/43248455/86859382-835daf00-c090-11ea-8e16-058d7c204aef.png)
- Spacing + newline issues between paragraphs in `Rule Description`
    ![image](https://user-images.githubusercontent.com/43248455/86859485-ba33c500-c090-11ea-9d23-54bb9e3d77c4.png)
- Instead of showing both short and full description, we do:
    - If full description is present, show full description
    - If full description is not present but short description is, show short description
    - If short description is not present, show empty state
