### PR TITLE
Testing Tool: View multiple layouts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
                 "prefer-const": ERROR,
 
                 "eqeqeq": ERROR,
-                "filenames/match-regex": [ERROR, "^([a-z0-9]+)([A-Z][a-z0-9]+)*(\.(config|d|spec))?$"],
+                "filenames/match-regex": [ERROR, "^([a-z0-9]+)([A-Z][a-z0-9]+)*(\.(config|d|layouts|spec))?$"],
                 "header/header": [ERROR, "line", [
                     " Copyright (c) Microsoft Corporation. All rights reserved.",
                     " Licensed under the MIT License.",

--- a/index.css
+++ b/index.css
@@ -418,3 +418,27 @@ kbd {
 ::-webkit-scrollbar-thumb:active {
     background-color: var(--vscode-scrollbarSlider-activeBackground);
 }
+
+/* Background overrides */
+body {
+    background-color: var(--vscode-menu-background);
+}
+
+body.pageIndex #root {
+    background-color: var(--vscode-editor-background);
+    margin: 50px 300px;
+    position: relative; /* relative for Popover */
+}
+
+body.pageDetailsLayouts .svDetailsLayouts {
+    margin: 50px;
+    display: grid;
+    grid-auto-flow: column;
+    grid-Gap: 50px;
+    grid-template-columns: 450px 450px auto;
+    grid-template-rows: auto auto;
+}
+
+body.pageDetailsLayouts .svDetailsPane {
+    background-color: var(--vscode-editor-background);
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ It mocks the html environment for `panel/Index.tsx`. Local Storage simulates `gl
         </style>
     </head>
     <body class="vscode-dark">
-        <div id="root" style="margin: 50px 300px; position: relative;"></div><!-- relative for Popover -->
+        <div id="root"></div>
         <script>
             acquireVsCodeApi = (() => ({ postMessage: message => {
                 const {command, ...rest} = message;

--- a/index.js
+++ b/index.js
@@ -37,8 +37,9 @@
     const log = await response.json();
     log._uri = `file:///Users/username/projects/${file}`;
     store.logs.push(log);
+    document.body.classList.add('pageIndex') // Alternatively 'pageDetailsLayouts'.
     ReactDOM.render(
-        React.createElement(Index, { store }),
+        React.createElement(Index, {store}), // Alternatively 'DetailsLayouts'.
         document.getElementById('root'),
     );
 })();

--- a/src/panel/Index.scss
+++ b/src/panel/Index.scss
@@ -7,7 +7,6 @@ html {
 body {
     height: 100%;
     padding: 0; /* Override */
-    background-color: var(--vscode-menu-background); // Borrowed from Explorer background
     display: flex;
     flex-direction: column;
     margin-left: 1px; // VS Code Webview splitter eats an extra pixel on the left.
@@ -38,7 +37,6 @@ mark {
     flex: 1 1 auto;
     display: flex;
     flex-direction: column;
-    background-color: var(--vscode-editor-background); // Restore from pre-body
     overflow: hidden;
 }
 

--- a/src/panel/details.layouts.tsx
+++ b/src/panel/details.layouts.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { observable } from 'mobx';
+import * as React from 'react';
+import { Component } from 'react';
+import { Result } from 'sarif';
+import { Details } from './details';
+
+// A development tool to see `Details` in multiple layout states at once.
+export class DetailsLayouts extends Component {
+    render() {
+        const result: Result = {
+            ruleId: 'DEMO01',
+            message: { text: 'A result' },
+            stacks: [],
+            _log: { _uri: 'file:///demo.sarif' },
+            _message: 'A result',
+            _run: {},
+        } as unknown as Result;
+
+        return <div className="svDetailsLayouts">
+            <Details result={result} height={observable.box(300)} />
+            <Details result={result} height={observable.box(600)} />
+            <Details result={result} height={observable.box(300)} />
+            <Details result={result} height={observable.box(600)} />
+        </div>;
+    }
+}

--- a/src/panel/index.tsx
+++ b/src/panel/index.tsx
@@ -19,6 +19,7 @@ import { Checkrow, Icon, Popover, ResizeHandle, Tab, TabPanel } from './widgets'
 export * as React from 'react';
 export * as ReactDOM from 'react-dom';
 export { IndexStore as Store } from './indexStore';
+export { DetailsLayouts } from './details.layouts';
 
 @observer export class Index extends Component<{ store: IndexStore }> {
     private showFilterPopup = observable.box(false)


### PR DESCRIPTION
Added a page for testing purposes. Allows a component to be rendered simultaneously in multiple states and sizes. Useful for identifying (unintended) side effects of CSS changes. I have some other improvements to make on this concept, but need to fix some other bugs first, so merging this in now.

![localhost  (6)](https://user-images.githubusercontent.com/3452831/87016293-5fc76100-c183-11ea-860b-ea347a5b8ea1.jpeg)
