### PR TITLE
Retroactive update of package-lock.json for `nyc`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,11 +39,230 @@
 				"@babel/highlight": "^7.10.1"
 			}
 		},
+		"@babel/core": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
+			"integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.10.5",
+				"@babel/helper-module-transforms": "^7.10.5",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.10.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.5",
+				"@babel/types": "^7.10.5",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.19",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"json5": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
+				"lodash": {
+					"version": "4.17.19",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+					"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+			"integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.5",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+			"integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.5"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+			"integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.5",
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.19",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+					"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
 		"@babel/helper-validator-identifier": {
 			"version": "7.10.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
 			"integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
 			"dev": true
+		},
+		"@babel/helpers": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
 		},
 		"@babel/highlight": {
 			"version": "7.10.1",
@@ -55,6 +274,203 @@
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
+		},
+		"@babel/parser": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+			"dev": true
+		},
+		"@babel/template": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				}
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+			"integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.10.5",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/parser": "^7.10.5",
+				"@babel/types": "^7.10.5",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.19",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+					"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+			"integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"lodash": "^4.17.19",
+				"to-fast-properties": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.19",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+					"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+					"dev": true
+				}
+			}
+		},
+		"@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
+		},
+		"@istanbuljs/schema": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+			"dev": true
 		},
 		"@microsoft/sarif-multitool-darwin": {
 			"version": "2.2.5",
@@ -758,6 +1174,24 @@
 				}
 			}
 		},
+		"aggregate-error": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+			"integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+			"dev": true,
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				}
+			}
+		},
 		"ajv": {
 			"version": "6.12.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
@@ -842,10 +1276,25 @@
 				"picomatch": "^2.0.4"
 			}
 		},
+		"append-transform": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+			"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "^3.0.0"
+			}
+		},
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
+		},
+		"archy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
 			"dev": true
 		},
 		"are-we-there-yet": {
@@ -1572,6 +2021,35 @@
 				}
 			}
 		},
+		"caching-transform": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+			"integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+			"dev": true,
+			"requires": {
+				"hasha": "^5.0.0",
+				"make-dir": "^3.0.0",
+				"package-hash": "^4.0.0",
+				"write-file-atomic": "^3.0.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1817,6 +2295,12 @@
 				}
 			}
 		},
+		"clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true
+		},
 		"cli-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -2059,6 +2543,15 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
 			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
 		},
 		"cookie": {
 			"version": "0.4.0",
@@ -2355,6 +2848,23 @@
 			"requires": {
 				"execa": "^1.0.0",
 				"ip-regex": "^2.1.0"
+			}
+		},
+		"default-require-extensions": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+			"integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+			"dev": true,
+			"requires": {
+				"strip-bom": "^4.0.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+					"dev": true
+				}
 			}
 		},
 		"define-properties": {
@@ -2761,6 +3271,12 @@
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
 			}
+		},
+		"es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -3713,6 +4229,59 @@
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
+		"foreground-child": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^3.0.2"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3760,6 +4329,12 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
 			}
+		},
+		"fromentries": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
+			"integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw==",
+			"dev": true
 		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
@@ -3871,10 +4446,22 @@
 				"globule": "^1.0.0"
 			}
 		},
+		"gensync": {
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+			"dev": true
+		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
 		"get-stdin": {
@@ -4202,6 +4789,24 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"hasha": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+			"integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
+			"dev": true,
+			"requires": {
+				"is-stream": "^2.0.0",
+				"type-fest": "^0.8.0"
+			},
+			"dependencies": {
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+					"dev": true
+				}
+			}
+		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -4250,6 +4855,12 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
 			"integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
+			"dev": true
+		},
+		"html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
 		"html-to-react": {
@@ -5053,6 +5664,207 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
 		},
+		"istanbul-lib-coverage": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+			"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+			"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+			"dev": true,
+			"requires": {
+				"append-transform": "^2.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.7.5",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-coverage": "^3.0.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-lib-processinfo": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+			"integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+			"dev": true,
+			"requires": {
+				"archy": "^1.0.0",
+				"cross-spawn": "^7.0.0",
+				"istanbul-lib-coverage": "^3.0.0-alpha.1",
+				"make-dir": "^3.0.0",
+				"p-map": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"uuid": "^3.3.3"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"p-map": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^3.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+			"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+			"dev": true,
+			"requires": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			}
+		},
 		"js-base64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
@@ -5078,6 +5890,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
 		"json-parse-better-errors": {
@@ -5244,6 +6062,12 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"dev": true
+		},
+		"lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
 		},
 		"lodash.get": {
@@ -5948,6 +6772,15 @@
 				}
 			}
 		},
+		"node-preload": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+			"integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+			"dev": true,
+			"requires": {
+				"process-on-spawn": "^1.0.0"
+			}
+		},
 		"node-sass": {
 			"version": "4.14.1",
 			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
@@ -6111,6 +6944,250 @@
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
+		},
+		"nyc": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+			"dev": true,
+			"requires": {
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"caching-transform": "^4.0.0",
+				"convert-source-map": "^1.7.0",
+				"decamelize": "^1.2.0",
+				"find-cache-dir": "^3.2.0",
+				"find-up": "^4.1.0",
+				"foreground-child": "^2.0.0",
+				"get-package-type": "^0.1.0",
+				"glob": "^7.1.6",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-hook": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.0",
+				"istanbul-lib-processinfo": "^2.0.2",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"make-dir": "^3.0.0",
+				"node-preload": "^0.2.1",
+				"p-map": "^3.0.0",
+				"process-on-spawn": "^1.0.0",
+				"resolve-from": "^5.0.0",
+				"rimraf": "^3.0.0",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^2.0.0",
+				"test-exclude": "^6.0.0",
+				"yargs": "^15.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"find-cache-dir": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^3.0.2",
+						"pkg-dir": "^4.1.0"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-map": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
@@ -6414,6 +7491,18 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
+		},
+		"package-hash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.15",
+				"hasha": "^5.0.0",
+				"lodash.flattendeep": "^4.4.0",
+				"release-zalgo": "^1.0.0"
+			}
 		},
 		"pako": {
 			"version": "1.0.11",
@@ -6750,6 +7839,15 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
+		},
+		"process-on-spawn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+			"integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+			"dev": true,
+			"requires": {
+				"fromentries": "^1.2.0"
+			}
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -7119,6 +8217,15 @@
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
 			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
 			"dev": true
+		},
+		"release-zalgo": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"dev": true,
+			"requires": {
+				"es6-error": "^4.0.1"
+			}
 		},
 		"remark-parse": {
 			"version": "5.0.0",
@@ -7952,6 +9059,55 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
+		"spawn-wrap": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+			"integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+			"dev": true,
+			"requires": {
+				"foreground-child": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"make-dir": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"signal-exit": "^3.0.2",
+				"which": "^2.0.1"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -8382,6 +9538,17 @@
 				"worker-farm": "^1.7.0"
 			}
 		},
+		"test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"requires": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			}
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8431,6 +9598,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
 		"to-object-path": {
@@ -8695,6 +9868,15 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
 		},
 		"typescript": {
 			"version": "3.8.3",
@@ -10089,6 +11271,18 @@
 			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1"
+			}
+		},
+		"write-file-atomic": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"dev": true,
+			"requires": {
+				"imurmurhash": "^0.1.4",
+				"is-typedarray": "^1.0.0",
+				"signal-exit": "^3.0.2",
+				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
 		"ws": {


### PR DESCRIPTION
`package.json` was modified in #284, however `package-lock.json` was not correspondingly modified.

@mukul-ms: Typically `npm install` will leave `package-lock.json` in a dirty state, naturally leading to a commit, which keeps everything in sync. Did this not occur for you?