### PR TITLE
Fix endColumn per spec 3.30.8.

### DIFF
--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -184,7 +184,7 @@ export function parseRegion(region: Region | undefined): _Region | undefined {
         startLine,
         startColumn,
         endLine ?? startLine,
-        endColumn ?? (startColumn + 1)
+        endColumn ?? Number.MAX_SAFE_INTEGER // Arbitrarily large number representing the rest of the line.
     ] as _RegionStartEndLineCol;
 }
 


### PR DESCRIPTION
Seeing more instances of `endColumn = undefined` lately and the previous placeholder solution was not to spec. Previously the selected range would be 1 char long. After this fix, it will go to the end of the line.