### PR TITLE
Version bump, add Github action to produce pre-release builds, and fix multitool issues.

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,42 @@
+name: Create Pre-release
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  createPrerelease:
+    name: Create Pre-release
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: |
+          npm install
+          npm install --force @microsoft/sarif-multitool-darwin @microsoft/sarif-multitool-win32
+          npx json -I -f package.json -e 'this.version = `${this.version}-${{ github.run_number }}`'
+          npm run package
+      - id: package_version
+        uses: Saionaro/extract-package-version@v1.1.1
+      - id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.package_version.outputs.version }}
+          release_name: ${{ steps.package_version.outputs.version }}
+          prerelease: true
+      - id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./sarif-viewer-${{ steps.package_version.outputs.version }}.vsix
+          asset_name: sarif-viewer-${{ steps.package_version.outputs.version }}.vsix
+          asset_content_type: application/vsix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "sarif-viewer",
-	"version": "2.16.0",
+	"version": "3.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -446,18 +446,6 @@
 			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
 			"dev": true
 		},
-		"@microsoft/sarif-multitool-darwin": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-darwin/-/sarif-multitool-darwin-2.3.3.tgz",
-			"integrity": "sha512-pGmPbxHMQLJSUV+d8G6JMcT0xeANOkf9+O38T2d59bI3YTfFW19LPg+nHhfzXnEewv2S1y55Bs4yukXoZzAHcA==",
-			"optional": true
-		},
-		"@microsoft/sarif-multitool-win32": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@microsoft/sarif-multitool-win32/-/sarif-multitool-win32-2.3.3.tgz",
-			"integrity": "sha512-FQmI81QpbK9ospl9Um5Q6uS7lGTBgZlojQqyQ6krIFOl8qNbqlpHSXv9akU/oQoyRRkkx8nvfpmx8njyaQqUyg==",
-			"optional": true
-		},
 		"@octokit/auth-token": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "The Sarif Viewer extension visualizes the results in a Sarif file",
     "author": "Microsoft Corporation",
     "license": "MIT",
-    "version": "2.16.0",
+    "version": "3.0.0",
     "publisher": "MS-SarifVSCode",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
         ]
     },
     "scripts": {
-        "postinstall": "npm install --force --E @microsoft/sarif-multitool-darwin @microsoft/sarif-multitool-win32",
         "prestart": "npm install",
         "start": "webpack --watch",
         "server": "webpack-dev-server -d",
@@ -152,9 +151,5 @@
         "vscode-codicons": "0.0.2",
         "vscode-extension-telemetry": "0.1.6",
         "vscode-uri": "2.1.2"
-    },
-    "optionalDependencies": {
-        "@microsoft/sarif-multitool-darwin": "2.3.3",
-        "@microsoft/sarif-multitool-win32": "2.3.3"
     }
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -19,7 +19,6 @@ export async function activate(context: ExtensionContext) {
     Telemetry.activate();
 
     const disposables = context.subscriptions;
-    Store.extensionPath = context.extensionPath;
     Store.globalState = context.globalState;
     disposables.push(commands.registerCommand('sarif.clearState', () => {
         context.globalState.update('view', undefined);

--- a/src/extension/loadLogs.ts
+++ b/src/extension/loadLogs.ts
@@ -5,13 +5,11 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import jsonMap from 'json-source-map';
-import { join } from 'path';
 import { Log } from 'sarif';
 import { eq, gt, lt } from 'semver';
 import { tmpNameSync } from 'tmp';
 import { ProgressLocation, Uri, window } from 'vscode';
 import { augmentLog, JsonMap } from '../shared';
-import { Store } from './store';
 
 export async function loadLogs(uris: Uri[], token?: { isCancellationRequested: boolean }) {
     const logs = uris
@@ -55,6 +53,7 @@ export async function loadLogs(uris: Uri[], token?: { isCancellationRequested: b
                         log._jsonMap = pointers;
                         logsNoUpgrade.push(log);
                     } catch (error) {
+                        console.error(error);
                         window.showErrorMessage(`Failed to upgrade '${fsPath}'`);
                     }
                 }
@@ -91,8 +90,6 @@ export function detectUpgrade(log: Log, logsNoUpgrade: Log[], logsToUpgrade: Log
 export function upgradeLog(fsPath: string) {
     // Example of a MacOS temp folder: /private/var/folders/9b/hn5353ks051gn79f4b8rn2tm0000gn/T
     const name = tmpNameSync({ postfix: '.sarif' });
-    const multitoolExe = `Sarif.Multitool${process.platform === 'win32' ? '.exe' : ''}`;
-    const multitoolExePath = join(Store.extensionPath || process.cwd(), 'out', multitoolExe);
-    execFileSync(multitoolExePath, ['transform', fsPath, '--force', '--pretty-print', '--output', name]);
+    execFileSync('npx', ['@microsoft/sarif-multitool', 'transform', fsPath, '--force', '--pretty-print', '--output', name]);
     return name;
 }

--- a/src/extension/store.ts
+++ b/src/extension/store.ts
@@ -8,7 +8,6 @@ import { mapDistinct } from '../shared';
 import '../shared/extension';
 
 export class Store {
-    static extensionPath: string | undefined
     static globalState: Memento
 
     @observable.shallow logs = [] as Log[]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const CopyPlugin = require('copy-webpack-plugin');
 const outputPath = require('path').join(__dirname, 'out');
 
 const common = {
@@ -80,11 +79,5 @@ module.exports = [
         externals: {
             vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded.
         },
-        plugins: [
-            new CopyPlugin([
-                { from: require('@microsoft/sarif-multitool-darwin') },
-                { from: require('@microsoft/sarif-multitool-win32') },
-            ]),
-        ],
     },
 ];


### PR DESCRIPTION
Been "cornered" by some Multitool issues recently:

1. The Darwin/Mac Multitool now has a `chmod` post-install script which won't run on Win32. So we can no longer "force" that install gracefully.
2. Been seeing some mysterious bugs (example is Henok) where the Win32 portable EXE doesn't behave after being VSIX-packed and unpacked. However `npx` for whatever reason has been more reliable.
3. The extra 200-300MB payload of the various versions of the Multitool has always slowed down `npm install`, deployment, and verification.

I'm trying a change in strategy: no longer packing the various flavors of multitool in the VSIX. Instead the extension will call `npx @microsoft/sarif-multitool`. This will download and cache the platform-specific binaries on demand. While this solves the larger issues, the small tradeoff is that first time the user requires a SARIF log upgrade: 1) internet access will be required and 2) the may be a delay (as it downloads the multitool).

@GabeDeBacker: This might be of interest to you.