### PR TITLE
Clear selection on zero logs.

### DIFF
--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -32,6 +32,11 @@ export class IndexStore {
             return change;
         });
 
+        observe(this.logs, () => {
+            if (this.logs.length) return;
+            this.selection.set(undefined);
+        });
+
         if (defaultSelection) {
             const store = this.resultTableStoreByLocation;
             when(() => !!store.rows.length, () => {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -221,7 +221,7 @@ export function parseArtifactLocation(result: Result, anyArtLoc: ArtifactLocatio
     // A shorter more transparent URI format would be:
     // `sarif://${encodeURIComponent(result._log._uri)}/${result._run._index}/${anyArtLoc.index}/${uri?.file ?? 'Untitled'}`
     // However between workspace.openTextDocument() and registerTextDocumentContentProvider/provideTextDocumentContent()
-    // VS Code fails to maintain the authority value (possibiliy due to an encoding bug).
+    // VS Code fails to maintain the authority value (possibly due to an encoding bug).
     const uriContents = runArtCon?.text || runArtCon?.binary
         ? encodeURI(`sarif:${encodeURIComponent(result._log._uri)}/${result._run._index}/${anyArtLoc.index}/${uri?.file ?? 'Untitled'}`)
         : undefined;


### PR DESCRIPTION
Strictly speaking we should check anytime a log is removed, but I question if anybody would notice the difference.

Fixes #277.