### PR TITLE
Reuse driverless rule instances across runs.

### DIFF
--- a/src/extension/loadLogs.ts
+++ b/src/extension/loadLogs.ts
@@ -5,11 +5,13 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import jsonMap from 'json-source-map';
-import { Log } from 'sarif';
+import { Log, ReportingDescriptor } from 'sarif';
 import { eq, gt, lt } from 'semver';
 import { tmpNameSync } from 'tmp';
 import { ProgressLocation, Uri, window } from 'vscode';
 import { augmentLog, JsonMap } from '../shared';
+
+const driverlessRules = new Map<string, ReportingDescriptor>();
 
 export async function loadLogs(uris: Uri[], token?: { isCancellationRequested: boolean }) {
     const logs = uris
@@ -60,7 +62,7 @@ export async function loadLogs(uris: Uri[], token?: { isCancellationRequested: b
             }
         );
     }
-    logsNoUpgrade.forEach(augmentLog);
+    logsNoUpgrade.forEach(log => augmentLog(log, driverlessRules));
     if (warnUpgradeExtension) {
         window.showWarningMessage('Some log versions are newer than this extension.');
     }

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -9,6 +9,8 @@ import { ResultTableStore } from './resultTableStore';
 import { Row, RowItem } from './tableStore';
 
 export class IndexStore {
+    private driverlessRules = new Map<string, ReportingDescriptor>();
+
     constructor(state: Record<string, Record<string, Record<string, Visibility>>>, defaultSelection?: boolean) {
         this.filtersRow = state.filtersRow;
         this.filtersColumn = state.filtersColumn;
@@ -28,7 +30,7 @@ export class IndexStore {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         intercept(this.logs, (change: any) => {
             if (change.type !== 'splice') throw new Error(`Unexpected change type. ${change.type}`);
-            change.added.forEach(augmentLog);
+            change.added.forEach((log: Log) => augmentLog(log, this.driverlessRules));
             return change;
         });
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -80,7 +80,7 @@ export function mapDistinct(pairs: [string, string][]): Map<string, string> {
     return distinct as Map<string, string>;
 }
 
-export function augmentLog(log: Log) {
+export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>) {
     if (log._augmented) return;
     log._augmented = true;
     const fileAndUris = [] as [string, string][];
@@ -91,7 +91,7 @@ export function augmentLog(log: Log) {
         // We intern these objects so they can be conveniently instance comparable elsewhere in the code.
         // If we don't do this, then the same ruleId may generate multiple `Rule` objects.
         // When instance comparing those `Rule` objects, they would appear to be different rules. We don't want that.
-        const driverlessRules = new Map<string, ReportingDescriptor>();
+        const driverlessRules = rules ?? new Map<string, ReportingDescriptor>();
         function getDriverlessRule(id: string | undefined): ReportingDescriptor | undefined {
             if (!id) return undefined;
             if (!driverlessRules.has(id)) {


### PR DESCRIPTION
Addresses the issue @GabeDeBacker reported of the Rules tab showing duplicate rules.

Note we're taking a tactical approach by just comparing ruleId. In the future if we see ruleId collisions, we can namespace them by tool name. The most strict approach would be to namespace by tool name+version. However, I don't anticipate this being a concern given the use cases I've seen.