### PR TITLE
Perf: Defer SARIF log source map generation.

### DIFF
--- a/src/extension/index.spec.ts
+++ b/src/extension/index.spec.ts
@@ -11,6 +11,9 @@ import { postSelectArtifact, postSelectLog } from '../panel/indexStore';
 import { log } from '../test/mockLog';
 import { mockVscode, mockVscodeTestFacing } from '../test/mockVscode';
 
+// Log object may be modified during testing, thus we need to keep a clean string copy.
+const mockLogString = JSON.stringify(log);
+
 const proxyquire = require('proxyquire').noCallThru();
 
 describe('activate', () => {
@@ -19,12 +22,15 @@ describe('activate', () => {
             'fs': {
                 '@global': true,
                 readFileSync: () => {
-                    return JSON.stringify(log);
+                    return mockLogString;
                 }
             },
             'vscode': {
                 '@global': true,
                 ...mockVscode,
+            },
+            './telemetry': {
+                activate: () => { },
             },
         });
         const api = await mockVscodeTestFacing.activateExtension(activate);

--- a/src/extension/loadLogs.ts
+++ b/src/extension/loadLogs.ts
@@ -4,12 +4,11 @@
 /// <reference path="jsonSourceMap.d.ts" />
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
-import jsonMap from 'json-source-map';
 import { Log, ReportingDescriptor } from 'sarif';
 import { eq, gt, lt } from 'semver';
 import { tmpNameSync } from 'tmp';
 import { ProgressLocation, Uri, window } from 'vscode';
-import { augmentLog, JsonMap } from '../shared';
+import { augmentLog } from '../shared';
 
 const driverlessRules = new Map<string, ReportingDescriptor>();
 
@@ -20,9 +19,8 @@ export async function loadLogs(uris: Uri[], token?: { isCancellationRequested: b
             try {
                 const file = fs.readFileSync(uri.fsPath, 'utf8')  // Assume scheme file.
                     .replace(/^\uFEFF/, ''); // Trim BOM.
-                const {data: log, pointers} = jsonMap.parse(file) as { data: Log, pointers: JsonMap};
+                const log = JSON.parse(file) as Log;
                 log._uri = uri.toString();
-                log._jsonMap = pointers;
                 return log;
             } catch (error) {
                 window.showErrorMessage(`Failed to parse '${uri.fsPath}'`);
@@ -49,10 +47,9 @@ export async function loadLogs(uris: Uri[], token?: { isCancellationRequested: b
                     try {
                         const tempPath = upgradeLog(fsPath);
                         const file = fs.readFileSync(tempPath, 'utf8'); // Assume scheme file.
-                        const {data: log, pointers} = jsonMap.parse(file) as { data: Log, pointers: JsonMap};
+                        const log = JSON.parse(file) as Log;
                         log._uri = oldLog._uri;
                         log._uriUpgraded = Uri.file(tempPath).toString();
-                        log._jsonMap = pointers;
                         logsNoUpgrade.push(log);
                     } catch (error) {
                         console.error(error);

--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as fs from 'fs';
+import jsonMap from 'json-source-map';
 import { autorun, IArraySplice, observable, observe } from 'mobx';
 import { Log, Result } from 'sarif';
 import { commands, ExtensionContext, TextEditorRevealType, Uri, ViewColumn, WebviewPanel, window, workspace } from 'vscode';
-import { CommandPanelToExtension, filtersColumn, filtersRow, ResultId, _Region } from '../shared';
+import { CommandPanelToExtension, filtersColumn, filtersRow, JsonMap, ResultId, _Region, _RegionStartEndLineCol } from '../shared';
 import { loadLogs } from './loadLogs';
 import { regionToSelection } from './regionToSelection';
 import { Store } from './store';
@@ -111,7 +113,17 @@ export class Panel {
                 const log = store.logs.find(log => log._uri === logUri);
                 const result = store.logs.find(log => log._uri === logUri)?.runs[runIndex]?.results?.[resultIndex];
                 if (!log || !result) return;
-                await this.selectLocal(logUri, log._uriUpgraded ?? log._uri, result._logRegion);
+
+                const logUriUpgraded = log._uriUpgraded ?? log._uri;
+                if (!log._jsonMap) {
+                    const file = fs.readFileSync(Uri.parse(logUriUpgraded).fsPath, 'utf8')  // Assume scheme file.
+                        .replace(/^\uFEFF/, ''); // Trim BOM.
+                    log._jsonMap = (jsonMap.parse(file) as { pointers: JsonMap }).pointers;
+                }
+
+                const { value, valueEnd } = log._jsonMap?.[`/runs/${runIndex}/results/${resultIndex}`];
+                const resultRegion = [value.line, value.column, valueEnd.line, valueEnd.column] as _RegionStartEndLineCol;
+                await this.selectLocal(logUri, logUriUpgraded, resultRegion);
                 break;
             }
             case 'setState': {

--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -121,7 +121,7 @@ export class Panel {
                     log._jsonMap = (jsonMap.parse(file) as { pointers: JsonMap }).pointers;
                 }
 
-                const { value, valueEnd } = log._jsonMap?.[`/runs/${runIndex}/results/${resultIndex}`];
+                const { value, valueEnd } = log._jsonMap[`/runs/${runIndex}/results/${resultIndex}`];
                 const resultRegion = [value.line, value.column, valueEnd.line, valueEnd.column] as _RegionStartEndLineCol;
                 await this.selectLocal(logUri, logUriUpgraded, resultRegion);
                 break;

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -11,7 +11,7 @@ export type JsonMap = Record<string, JsonRange>
 
 export type ResultId = [string, number, number]
 type _RegionBytes = [number, number] // byteOffset, byteLength
-type _RegionStartEndLineCol = [number, number, number, number] // start line, start col, end line, end col
+export type _RegionStartEndLineCol = [number, number, number, number] // start line, start col, end line, end col
 export type _Region
     = number // single line
     | _RegionBytes
@@ -38,7 +38,6 @@ declare module 'sarif' {
         _log: Log;
         _run: Run;
         _id: ResultId;
-        _logRegion?: _Region;
         _uri?: string;
         _uriContents?: string; // ArtifactContent. Do not use this uri for display.
         _relativeUri?: string;
@@ -105,12 +104,6 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>) {
             result._log = log;
             result._run = run;
             result._id = [log._uri, runIndex, resultIndex];
-            result._logRegion = (() => {
-                const region = log._jsonMap?.[`/runs/${runIndex}/results/${resultIndex}`];
-                if (!region) return; // Panel will not have a jsonMap
-                const {value, valueEnd} = region;
-                return [ value.line, value.column, valueEnd.line, valueEnd.column ] as _Region;
-            })();
 
             const ploc = result.locations?.[0]?.physicalLocation;
             const [uri, uriContents] = parseArtifactLocation(result, ploc?.artifactLocation);
@@ -151,7 +144,6 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>) {
         });
     });
     log._distinct = mapDistinct(fileAndUris);
-    log._jsonMap = undefined; // Free-up memory.
 }
 
 /*


### PR DESCRIPTION
This is an alternative to #332. In #322 we selectively disable. In this one we always defer. This is in response to feedback that not all large SARIF files exclusively enter via the API.

Addresses a perf issue where a 150MB log takes 14s to load. With this fix it takes 3.5s. Memory pressure is no longer limited at 500MB. It seems to be smooth over 1.5GB now (no heap issues).

Note: Clicking on a "navigate to log result source" will be slower the first time since we are deferring the work. However, it might not be perceptible and also this is a producer-targeted feature (narrow audience). Thus we can deal with adding a progress bar at a later date (upon feedback).

#### Attaching our internal mail thread here:

I investigated (profiled) Roy's 150MB SARIF log. On my (slow) machine it takes ~14s to load. 10.5s of that is generating the source map. We can (situationally) drop the source map and shave 75% of the time.

What is the source map for? When you click the "6101_1.sarif" link below, it takes to you the region in the SARIF Log source. The source map powers that. A feature primarily for SARIF producers, not consumers.

![Screen Shot 2020-08-14 at 2 02 16 AM](https://user-images.githubusercontent.com/3452831/90277867-37cebb80-de1b-11ea-80b3-db853c32bcb7.png)

A few options to situationally disable the source map:
* Auto-disable on large files. Not great as many small files can still cause trouble.
* Add a user setting. I don't think it will be discoverable and we would still need smart defaults.
* Lazy-create the source map when that link is clicked. User may be surprised there is a long wait. Also makes the code more-stateful, which I recommend against.
* Auto-disable on API-triggered SARIF log opens. I'm recommending this one.

Thoughts? If nobody cares (say in 24 hours), I'll go with my recommendation. Thanks.