### PR TITLE
Fix #335: Filter state persistence.

### DIFF
--- a/src/panel/detailsFeedback.tsx
+++ b/src/panel/detailsFeedback.tsx
@@ -11,14 +11,14 @@ import { Checkrow } from './widgets';
 
 @observer export class DetailsFeedback extends Component {
     @observable feedbackTags: Record<string, Visibility> = {
-        'Useful (#useful)': undefined,
-        'False (#falsepositive)': undefined,
-        'Not Actionable (#notactionable)': undefined,
-        'Low Value (#lowvalue)': undefined,
-        'Code Does Not Ship (#doesnotship)': undefined,
-        '3rd Party/OSS Code (#3rdpartycode)': undefined,
-        'Feature Request (#featurerequest)': undefined,
-        'Other (#other)': undefined,
+        'Useful (#useful)': false,
+        'False (#falsepositive)': false,
+        'Not Actionable (#notactionable)': false,
+        'Low Value (#lowvalue)': false,
+        'Code Does Not Ship (#doesnotship)': false,
+        '3rd Party/OSS Code (#3rdpartycode)': false,
+        'Feature Request (#featurerequest)': false,
+        'Other (#other)': false,
     }
     render() {
         const {feedbackTags} = this;
@@ -36,13 +36,13 @@ import { Checkrow } from './widgets';
                     </textarea>
                     <Checkrow label={'I need help NOW'}
                         description={'I need urgent support from the checker owner.'}
-                        state={{ 'I need help NOW': undefined }} />
+                        state={{ 'I need help NOW': false }} />
                     <Checkrow label={'Tented Code'}
                         description={'Do not upload my source file to the static analysis team.'}
-                        state={{ 'Tented Code': undefined }} />
+                        state={{ 'Tented Code': false }} />
                     <Checkrow label={'Send Full Dataset'}
                         description={'Uncheck if you don\'t want to upload extra diagnostic data to the checker owner.'}
-                        state={{ 'Tented Code': undefined }} />
+                        state={{ 'Tented Code': false }} />
                     <input type="button" value={'Submit Feedback'}></input>
                 </div>
             </div>

--- a/src/panel/widgets.tsx
+++ b/src/panel/widgets.tsx
@@ -24,7 +24,7 @@ export class Badge extends PureComponent<{ text: { toString: () => string } }> {
 @observer export class Checkrow extends PureComponent<{ label: string, description?: string, state: Record<string, Visibility>}> {
     render() {
         const {label, description, state} = this.props;
-        return <div className={css('svCheckrow', description && 'svWithDescription')} onClick={() => state[label] = state[label] === 'visible' ? undefined : 'visible'}>
+        return <div className={css('svCheckrow', description && 'svWithDescription')} onClick={() => state[label] = state[label] === 'visible' ? false : 'visible'}>
             <div className={css('svCheckbox', state[label] && 'svChecked')} tabIndex={0}
                 role="checkbox" aria-checked="false" aria-label="" title="">
                 <Icon name="check" />

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -225,7 +225,7 @@ export function decodeFileUri(uriString: string) {
     return uri.scheme === 'file' ? uri.fsPath : uriString;
 }
 
-export type Visibility = 'visible' | undefined;
+export type Visibility = 'visible' | false; // Undefined will not round-trip.
 
 export const filtersRow: Record<string, Record<string, Visibility>> = {
     Level: {
@@ -238,19 +238,19 @@ export const filtersRow: Record<string, Record<string, Visibility>> = {
         'New': 'visible',
         'Unchanged': 'visible',
         'Updated': 'visible',
-        'Absent': undefined,
+        'Absent': false,
     },
     Suppression: {
         'Not Suppressed': 'visible',
-        'Suppressed': undefined,
+        'Suppressed': false,
     },
 };
 
 export const filtersColumn: Record<string, Record<string, Visibility>> = {
     Columns: {
-        'Baseline': undefined,
-        'Suppression': undefined,
-        'Rule': undefined,
+        'Baseline': false,
+        'Suppression': false,
+        'Rule': false,
     },
 };
 


### PR DESCRIPTION
Indirectly related to #335.

For a while `{ foo: undefined }` would evaluate as is. However lately it started evaluating as `{}`. Either way `false` fixes it.

Practical implication was that certain values of the filter dropdown would be missing.