### PR TITLE
Drop support for log upgrades. Warn instead.

### DIFF
--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -78,7 +78,7 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>) {
     if (log._augmented) return;
     log._augmented = true;
     const fileAndUris = [] as [string, string][];
-    log.runs.forEach((run, runIndex) => {
+    log.runs?.forEach((run, runIndex) => { // types.d.ts is wrong, per spec `runs` is allowed to be null.
         run._index = runIndex;
 
         // For `Run`s that lack `tool.driver.rules` we generate a `Rule` object on demand.


### PR DESCRIPTION
Our upgrade process has always been a thorn. The Multitool binaries constitute over 99% of our VSIX weight. Upgrading cannot be done in memory (only on disk). Also, we had some platform-specific failures that were difficult to reproduce.

I discussed with @michaelcfanning, and the SARIF ecosystem advocates using the latest version (2.1.0 rtm5). The long term plan is not to perpetually have the viewers support older versions. There will always be ways outside of the viewer to upgrade these files.

Thus dropping support for upgrade in this PR. We will be listening for customer feedback and have a plan in place in case it is largely negative. On the other hand, if this works out, I think it will be good for everyone.

Rider: I fixed up some of the unit tests.