### PR TITLE
Add a "Remove All Logs" button

### DIFF
--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -101,6 +101,10 @@ export class Panel {
                 store.logs.removeFirst(log => log._uri === message.uri);
                 break;
             }
+            case 'removeAllLogs': {
+                store.logs.splice(0, store.logs.length);
+                break;
+            }
             case 'select': {
                 const {logUri, uri, region} = message as { logUri: string, uri: string, region: Region};
                 const validatedUri = await basing.translateArtifactToLocal(uri);

--- a/src/panel/index.tsx
+++ b/src/panel/index.tsx
@@ -57,6 +57,9 @@ export { DetailsLayouts } from './details.layouts';
                             title={allCollapsed ? 'Expand All' : 'Collapse All'}
                             onClick={() => activeTableStore?.groupsFilteredSorted.forEach(group => group.expanded = allCollapsed) } />
                         <Icon name="folder-opened" title="Open Log" onClick={() => vscode.postMessage({ command: 'open' })} />
+                        <Icon name="close-all" title="Remove All Logs" onClick={
+                            () => vscode.postMessage({ command: 'removeAllLogs' })
+                        }/>
                     </>}>
                     <Tab name={store.tabs[0]} count={store.resultTableStoreByLocation.groupsFilteredSorted.length}>
                         <ResultTable store={store.resultTableStoreByLocation} onClearFilters={() => store.clearFilters()}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -226,5 +226,5 @@ export const filtersColumn: Record<string, Record<string, Visibility>> = {
     },
 };
 
-export type CommandPanelToExtension = 'open' | 'removeLog' | 'select' | 'selectLog' | 'setState';
+export type CommandPanelToExtension = 'open' | 'removeLog' | 'removeAllLogs' | 'select' | 'selectLog' | 'setState';
 export type CommandExtensionToPanel = 'select' | 'spliceLogs';


### PR DESCRIPTION
When working with a large number of log files, it can be tedious to
click "x" on each log file. This adds a button that removes (closes)
all log files at once.

This resolves #351 .
