### PR TITLE
fix line number off by one

### DIFF
--- a/src/extension/regionToSelection.ts
+++ b/src/extension/regionToSelection.ts
@@ -26,6 +26,11 @@ export function regionToSelection(doc: TextDocument, region: Region | undefined)
     if (startLine !== undefined) {
         const line = doc.lineAt(startLine - 1);
         const minusOne = (n: number | undefined) => n === undefined ? undefined : n - 1;
+        /**
+         * Note according to SARIF format standard, line (number) is 1-based,
+         * AND VS Code shows lines as 1-based to the user, but internally VS Code `Range`s are 0-based,
+         * So we need to minus one on line numbers of SARIF region before using them to construct VS Code Selection object.
+         */
         return new Selection(
             startLine - 1,
             minusOne(region.startColumn) ?? line.firstNonWhitespaceCharacterIndex, // Trimming whitespace for default startColumn value.

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -39,7 +39,6 @@ declare module 'sarif' {
 
         /**
          * Caching the line number as derived from _region. Primarily user-facing and thus is 1-based. 0 if empty.
-         * Note VS Code shows lines as 1-based to the user, but internally VS Code `Range`s are 0-based.
          * */
         _line: number;
 
@@ -115,8 +114,7 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>) {
                 }
             }
             result._region = ploc?.region;
-            const zeroBasedLineNumber = result._region?.startLine ?? -1;
-            result._line = zeroBasedLineNumber + 1; // Convert 0-based to 1-based. See `_line` for reason.
+            result._line = result._region?.startLine ?? -1;
 
             result._rule = run.tool.driver.rules?.[result.ruleIndex ?? -1] // If result.ruleIndex is undefined, that's okay.
                 ?? run.tool.driver.rules?.find(rule => rule.id === result.ruleId)


### PR DESCRIPTION
related issue: https://github.com/microsoft/sarif-vscode-extension/issues/300

line number is still off by one for now after fixing issue #300 
![image](https://user-images.githubusercontent.com/3396288/109278468-8857b480-7853-11eb-8723-c10411693bab.png)

Note according to SARIF format standard, line (number) is 1-based, and VS Code shows lines as 1-based to the user, but internally VS Code `Range`s are 0-based, so we need to minus one on line numbers of SARIF region before using them to construct VS Code Selection object.