### PR TITLE
Fix line number offset by 1

### DIFF
--- a/src/shared/index.spec.ts
+++ b/src/shared/index.spec.ts
@@ -33,7 +33,7 @@ describe('augmentLog', () => {
     it('add augmented fields', () => {
         augmentLog(log);
         assert.strictEqual(result._uri, 'file:///folder/file.txt');
-        assert.strictEqual(result._line, -1);
+        assert.strictEqual(result._line, 0);
         assert.strictEqual(result._message, 'Message 1');
     });
 

--- a/src/shared/index.spec.ts
+++ b/src/shared/index.spec.ts
@@ -33,7 +33,7 @@ describe('augmentLog', () => {
     it('add augmented fields', () => {
         augmentLog(log);
         assert.strictEqual(result._uri, 'file:///folder/file.txt');
-        assert.strictEqual(result._line, 0);
+        assert.strictEqual(result._line, -1);
         assert.strictEqual(result._message, 'Message 1');
     });
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -109,7 +109,7 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>) {
                 }
             }
             result._region = ploc?.region;
-            result._line = result._region?.startLine ?? -1;
+            result._line = result._region?.startLine ?? 0;
 
             result._rule = run.tool.driver.rules?.[result.ruleIndex ?? -1] // If result.ruleIndex is undefined, that's okay.
                 ?? run.tool.driver.rules?.find(rule => rule.id === result.ruleId)

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -36,13 +36,7 @@ declare module 'sarif' {
         _uriContents?: string; // ArtifactContent. Do not use this uri for display.
         _relativeUri?: string;
         _region?: Region;
-
-        /**
-         * Caching the line number as derived from _region. Primarily user-facing and thus is 1-based. 0 if empty.
-         * Note VS Code shows lines as 1-based to the user, but internally VS Code `Range`s are 0-based.
-         * */
         _line: number;
-
         _rule?: ReportingDescriptor;
         _message: string; // '—' if empty.
         _markdown?: string;
@@ -115,8 +109,7 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>) {
                 }
             }
             result._region = ploc?.region;
-            const zeroBasedLineNumber = result._region?.startLine ?? -1;
-            result._line = zeroBasedLineNumber + 1; // Convert 0-based to 1-based. See `_line` for reason.
+            result._line = result._region?.startLine ?? -1;
 
             result._rule = run.tool.driver.rules?.[result.ruleIndex ?? -1] // If result.ruleIndex is undefined, that's okay.
                 ?? run.tool.driver.rules?.find(rule => rule.id === result.ruleId)


### PR DESCRIPTION
This PR addresses these open issues:
- https://github.com/microsoft/sarif-vscode-extension/issues/397
- https://github.com/microsoft/sarif-vscode-extension/issues/373

The existing code assumes that the line number passed from a sarif result location is zero-indexed. However, the line numbers are already 1-indexed. See https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317690 which describes `startLine`, for example, as a positive integer. 

See also https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317409, which indicates that line numbers are 1-based.