### PR TITLE
Retire Result._line.

### DIFF
--- a/src/panel/resultTable.tsx
+++ b/src/panel/resultTable.tsx
@@ -27,7 +27,7 @@ interface ResultTableProps<G> {
     private renderCell = (column: Column<Result>, result: Result) => {
         const customRenderers = {
             'File':     result => <span title={result._uri}>{result._uri?.file ?? '—'}</span>,
-            'Line':     result => <span>{result._line < 1 ? '—' : result._line}</span>,
+            'Line':     result => <span>{result._region?.startLine ?? '—'}</span>,
             'Message':  result => <span>{renderMessageTextWithEmbeddedLinks(result._message, result, vscode.postMessage)}</span>,
             'Rule':     result => <>
                 <span>{result._rule?.name ?? '—'}</span>

--- a/src/panel/resultTableStore.spec.ts
+++ b/src/panel/resultTableStore.spec.ts
@@ -25,7 +25,7 @@ describe('ResultTableStore', () => {
         const resultTableStore1 = new ResultTableStore('File', result => result._relativeUri, resultsSource, filtersSource, selection);
         assert.deepStrictEqual(resultTableStore1.visibleColumns.map((col) => col.name), ['Line', 'Message']);
 
-        const resultTableStore2 = new ResultTableStore('Line', result => result._line, resultsSource, filtersSource, selection);
+        const resultTableStore2 = new ResultTableStore('Line', result => result._region?.startLine ?? 0, resultsSource, filtersSource, selection);
         assert.deepStrictEqual(resultTableStore2.visibleColumns.map((col) => col.name), ['File', 'Message']);
 
         const resultTableStore3 = new ResultTableStore('Message', result => result._message, resultsSource, filtersSource, selection);

--- a/src/panel/resultTableStore.ts
+++ b/src/panel/resultTableStore.ts
@@ -27,7 +27,7 @@ export class ResultTableStore<G> extends TableStore<Result, G> {
 
     // Columns
     private columnsPermanent = [
-        new Column<Result>('Line', 50, result => result._line + '', result => result._line),
+        new Column<Result>('Line', 50, result => result._region?.startLine?.toString() ?? '—', result => result._region?.startLine ?? 0),
         new Column<Result>('File', 250, result => result._relativeUri ?? ''),
         new Column<Result>('Message', 300, result => result._message ?? ''),
     ]

--- a/src/shared/index.spec.ts
+++ b/src/shared/index.spec.ts
@@ -33,7 +33,6 @@ describe('augmentLog', () => {
     it('add augmented fields', () => {
         augmentLog(log);
         assert.strictEqual(result._uri, 'file:///folder/file.txt');
-        assert.strictEqual(result._line, 0);
         assert.strictEqual(result._message, 'Message 1');
     });
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -36,7 +36,6 @@ declare module 'sarif' {
         _uriContents?: string; // ArtifactContent. Do not use this uri for display.
         _relativeUri?: string;
         _region?: Region;
-        _line: number;
         _rule?: ReportingDescriptor;
         _message: string; // '—' if empty.
         _markdown?: string;
@@ -109,7 +108,6 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>) {
                 }
             }
             result._region = ploc?.region;
-            result._line = result._region?.startLine ?? 0;
 
             result._rule = run.tool.driver.rules?.[result.ruleIndex ?? -1] // If result.ruleIndex is undefined, that's okay.
                 ?? run.tool.driver.rules?.find(rule => rule.id === result.ruleId)


### PR DESCRIPTION
While reviewing #399, I realized `Result._region` has evolved to point where `Result._line` is no longer needed. Thus removing `_line` and simplifying things.