### PR TITLE
Mitigate selection sync feedback.

### DIFF
--- a/src/extension/index.spec.ts
+++ b/src/extension/index.spec.ts
@@ -7,7 +7,7 @@
 
 import assert from 'assert';
 import { URI as Uri } from 'vscode-uri';
-import { postSelectArtifact, postSelectLog } from '../panel/indexStore';
+import { postSelectLog } from '../panel/indexStore';
 import { log } from '../test/mockLog';
 import { mockVscode, mockVscodeTestFacing } from '../test/mockVscode';
 
@@ -38,6 +38,11 @@ describe('activate', () => {
     });
 
     it('can postSelectArtifact', async () => {
+        const { postSelectArtifact } = proxyquire('../panel/indexStore', {
+            '../panel/isActive': {
+                isActive: () => true,
+            },
+        });
         const result = mockVscodeTestFacing.store!.results[0]!;
         await postSelectArtifact(result, result.locations![0].physicalLocation);
         assert.deepEqual(mockVscodeTestFacing.events.splice(0), [

--- a/src/panel/index.tsx
+++ b/src/panel/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { autorun, IReactionDisposer, observable } from 'mobx';
+import { observable } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { Component, Fragment } from 'react';
@@ -11,7 +11,7 @@ import '../shared/extension';
 import { Details } from './details';
 import { FilterKeywordContext } from './filterKeywordContext';
 import './index.scss';
-import { IndexStore, postSelectArtifact } from './indexStore';
+import { IndexStore } from './indexStore';
 import { ResultTable } from './resultTable';
 import { RowItem } from './tableStore';
 import { Checkrow, Icon, Popover, ResizeHandle, Tab, TabPanel } from './widgets';
@@ -115,20 +115,11 @@ export { DetailsLayouts } from './details.layouts';
         </FilterKeywordContext.Provider>;
     }
 
-    private selectionAutoRunDisposer = null as IReactionDisposer | null
-
     componentDidMount() {
         addEventListener('message', this.props.store.onMessage);
-        this.selectionAutoRunDisposer = autorun(() => {
-            const selectedRow = this.props.store.selection.get();
-            const result = selectedRow instanceof RowItem && selectedRow.item;
-            if (!result?._uri) return; // Bail on no result or location-less result.
-            postSelectArtifact(result, result.locations?.[0]?.physicalLocation);
-        });
     }
 
     componentWillUnmount() {
         removeEventListener('message', this.props.store.onMessage);
-        this.selectionAutoRunDisposer?.();
     }
 }

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { action, computed, intercept, observable, observe, toJS, when } from 'mobx';
+import { action, autorun, computed, intercept, observable, observe, toJS, when } from 'mobx';
 import { Log, PhysicalLocation, ReportingDescriptor, Result } from 'sarif';
 import { augmentLog, CommandExtensionToPanel, filtersColumn, filtersRow, parseArtifactLocation, Visibility } from '../shared';
 import '../shared/extension';
@@ -47,6 +47,13 @@ export class IndexStore {
                 this.selection.set(item);
             });
         }
+
+        autorun(() => {
+            const selectedRow = this.selection.get();
+            const result = selectedRow instanceof RowItem && selectedRow.item;
+            if (!result?._uri) return; // Bail on no result or location-less result.
+            postSelectArtifact(result, result.locations?.[0]?.physicalLocation);
+        });
     }
 
     // Results

--- a/src/panel/isActive.ts
+++ b/src/panel/isActive.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Using `document.hasFocus()` as the indicator of if this panel is active or not.
+export function isActive() {
+    return document.hasFocus();
+}

--- a/src/test/mockVscode.ts
+++ b/src/test/mockVscode.ts
@@ -78,6 +78,7 @@ export const mockVscode = {
                 },
             };
         },
+        onDidChangeTextEditorSelection: () => {},
         showErrorMessage: (message: any) => console.error(`showErrorMessage: '${message}'`),
         showInformationMessage: async (_message: string, ...choices: string[]) => choices[0], // = [0] => 'Locate...'
         showOpenDialog: async () => mockVscodeTestFacing.showOpenDialogResult!.map(path => ({ path })),


### PR DESCRIPTION
This is a fix for #406.

The added strategy is to distinguish between active and inactive tabs. Same as before, active tabs will broadcast selection changed events. Inactive tabs will still listen and update their selection state. However inactive tabs will no longer broadcast these 2nd-order selection changes back to others. Thus breaking the feedback loop.

Note: Selection sync logic is now decoupled from Decorations and Code Actions. Selection sync is now editor-specific (for active/inactive) and thus require the `onDidChangeTextEditorSelection` API. Decorations and Code Actions don't provide the editor context as they are editor-agnostic and only document-specific. For those wondering, it was previously coupled out of convenience. The Code Actions API conveniently provided the decorations at the position.

Testing is in progress and a bit complicated since it requires specific conditions to reproduce the original issue. Posting this PR in advance of testing due to the urgency of this fix.