### PR TITLE
Limit `findFiles` against very large workspaces.

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -41,8 +41,9 @@ export async function activate(context: ExtensionContext) {
     //     8000      500-600ms
     //     20000     600ms
     //     1 of 20K  100ms (Only 1 file matches, but 20K need to be searched)
-    //     Note" `File: Exclude` setting is respected.
-    const urisNonSarif = await workspace.findFiles('**', '.sarif', 1000); // Ignore folders?
+    //     Note: `File: Exclude` setting is respected.
+    //     Hardware: 2020 MacBook Pro i7
+    const urisNonSarif = await workspace.findFiles('**', '.sarif', 10000); // Ignore folders?
     const fileAndUris = urisNonSarif.map(uri => [platformUriNormalize(uri.path).file, uri.toString(true /* skipEncoding */)]) as [string, string][];
     const baser = new UriRebaser(mapDistinct(fileAndUris), store);
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -33,7 +33,16 @@ export async function activate(context: ExtensionContext) {
     const store = new Store();
 
     // Basing
-    const urisNonSarif = await workspace.findFiles('**/*', '.sarif'); // Ignore folders?
+    //
+    // `findFiles` performance assuming '**':
+    //     files     ms
+    //     1000      200ms
+    //     4000      200-500ms
+    //     8000      500-600ms
+    //     20000     600ms
+    //     1 of 20K  100ms (Only 1 file matches, but 20K need to be searched)
+    //     Note" `File: Exclude` setting is respected.
+    const urisNonSarif = await workspace.findFiles('**', '.sarif', 1000); // Ignore folders?
     const fileAndUris = urisNonSarif.map(uri => [platformUriNormalize(uri.path).file, uri.toString(true /* skipEncoding */)]) as [string, string][];
     const baser = new UriRebaser(mapDistinct(fileAndUris), store);
 


### PR DESCRIPTION
Addresses #402. Thanks to @chrishuynhc, we suspect `findFiles` to be the culprit. Taking the straightforward route and limiting results to 10K which is ~600ms on a 2020 MacBook Pro i7. The `sarif-sdk` repo, for example, is under 3000 files.

Actually supporting rebasing for ~millions of files would require more work. I don't think we want to block this fix, even if we decide to pursue that. Also according to Chris, folks opening a million-file workspace often aren't intending to browse SARIF results on such a large scale. There also would be other bottleneck to solve outside of `findFiles`.

If extension load time for a workspace with ~10K files is a concern, we still have headroom to optimize. Namely, we could (and eventually should) call `findFiles` more tactically and lazily rather and not eagerly during load.

I contemplated showing a warning to the user when the 10K limit is reached. Basically the probability of the matching local and SARIF log files (URIs) goes down the further you go over the limit. It's a bit of an awkward message, so I refrained for now.
