### PR TITLE
Fix webview loading race.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sarif-viewer",
-    "version": "3.0.2",
+    "version": "3.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sarif-viewer",
-            "version": "3.0.2",
+            "version": "3.1.1",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Adds support for viewing SARIF logs",
     "author": "Microsoft Corporation",
     "license": "MIT",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "publisher": "MS-SarifVSCode",
     "repository": {
         "type": "git",

--- a/src/test/mockVscode.ts
+++ b/src/test/mockVscode.ts
@@ -65,7 +65,18 @@ export const mockVscode = {
                 filtersRow,
                 filtersColumn,
             };
-            mockVscodeTestFacing.store = new IndexStore(defaultState);
+
+            // Simulate the top-level script block of the webview.
+            (async () => {
+                mockVscodeTestFacing.store = new IndexStore(defaultState);
+                const spliceLogsData = {
+                    command: 'spliceLogs',
+                    removed: [],
+                    added: [{ uri: 'file:///.sarif/test.sarif', webviewUri: 'anyValue' }]
+                };
+                await mockVscodeTestFacing.store.onMessage({ data: spliceLogsData } as any);
+            })();
+
             return {
                 onDidDispose: () => {},
                 webview: {


### PR DESCRIPTION
Fixes #405. Under high-latency situations (namely remote development mode), the call to load (aka `splice`) Logs into the webview arrives before the webview as fully loaded (specifically, before it starts listening for messages). This commonly results in an "empty" webview. This fix integrates the log loading synchronously into the page load script.