### PR TITLE
Fix "Insiders" auto-update mechanism, update CODEOWNERS, Git Ignore.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @jeffersonking @GabeDeBacker @lgolding @sherryyshi
+*       @jeffersonking @GabeDeBacker @EasyRhinoMSFT

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ devServer/index.js
 *.vsix
 coverage
 .nyc_output
+ignore/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sarif-viewer",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sarif-viewer",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "1.14.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Adds support for viewing SARIF logs",
     "author": "Microsoft Corporation",
     "license": "MIT",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "publisher": "MS-SarifVSCode",
     "repository": {
         "type": "git",

--- a/src/extension/update.spec.ts
+++ b/src/extension/update.spec.ts
@@ -13,7 +13,18 @@ const proxyquire = require('proxyquire').noCallThru();
 const releases = [
     {
         'tag_name': 'v3.0.1-0',
-        'assets_url': 'https://api.github.com/repos/microsoft/sarif-vscode-extension/releases/26068659/assets'
+        'assets_url': 'https://api.github.com/repos/microsoft/sarif-vscode-extension/releases/26068659/assets',
+        'assets': [
+            {
+                'url': 'https://api.github.com/repos/microsoft/sarif-vscode-extension/releases/assets/20315654',
+                'name': 'MS-SarifVSCode.sarif-viewer.vsix',
+                'label': '',
+                'content_type': 'application/vsix',
+                'state': 'uploaded',
+                'size': 112615432,
+                'browser_download_url': 'https://github.com/microsoft/sarif-vscode-extension/releases/download/v3.2020.430009-insiders/MS-SarifVSCode.sarif-viewer.vsix'
+            }
+        ]
     },
     {
         'tag_name': 'v3.0.0', // installedVersion
@@ -41,19 +52,6 @@ const releases = [
     }
 ];
 
-// https://api.github.com/repos/microsoft/sarif-vscode-extension/releases/assets/20315654
-const assets = [
-    {
-        'url': 'https://api.github.com/repos/microsoft/sarif-vscode-extension/releases/assets/20315654',
-        'name': 'MS-SarifVSCode.sarif-viewer.vsix',
-        'label': '',
-        'content_type': 'application/octet-stream',
-        'state': 'uploaded',
-        'size': 112615432,
-        'browser_download_url': 'https://github.com/microsoft/sarif-vscode-extension/releases/download/v3.2020.430009-insiders/MS-SarifVSCode.sarif-viewer.vsix'
-    }
-];
-
 const makeStubs = () => ({
     'follow-redirects': {
         https: {
@@ -74,8 +72,6 @@ const makeStubs = () => ({
     'node-fetch': async (url: string) => {
         if (url.endsWith('releases'))
             return { status: 200, json: async () => releases };
-        if (url.endsWith('assets'))
-            return { status: 200, json: async () => assets };
         return undefined;
     },
     'vscode': {


### PR DESCRIPTION
The GitHub `releases` API has changed, this fixes our auto-update mechanism to match.

`CODEOWNERS` has been updated:
* @sherryyshi indicated that she has moved to another project thus removing her.
* Larry left this project some time ago, thus removing him.
* I'm adding @EasyRhinoMSFT as a backup so we don't get blocked on reviews in case someone is out on vacation. Chris works mainly on the Visual Studio extension, but would be my backup in case I am out.

Also updating `.gitignore` to ignore the `ignore/` folder. I often need a in-project space to keep some personal notes not suitable/relevant for checking-in. I am proposing this folder as a convention for that.