### PR TITLE
Fix: Schema URL Updates

### DIFF
--- a/src/extension/loadLogs.ts
+++ b/src/extension/loadLogs.ts
@@ -58,8 +58,8 @@ export function detectUpgrade(log: Log, logsNoUpgrade: Log[], logsToUpgrade: Log
             ?.replace('https://schemastore.azurewebsites.net/schemas/json/sarif-', '')
             ?.replace(/\.json$/, '');
         if (schema === undefined || schema === '2.1.0-rtm.5'
-            || schema === 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0'
-            || schema === 'https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0') {
+            || schema === 'https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0'
+            || schema === 'https://json.schemastore.org/sarif-2.1.0') {
             // https://github.com/microsoft/sarif-vscode-extension/issues/330
             logsNoUpgrade.push(log);
         } else {


### PR DESCRIPTION
The schema URLs were broken recently. This updates them to current, valid URLs. 
It also addresses checking the schema URL used by CodeQL when generating a Sarif file. 
Addresses issue #427 