### PR TITLE
Fix stack selection in panel

### DIFF
--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -154,10 +154,10 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                             return this.stacks.map((stack, key) => {
                                 const stackFrames = stack.frames;
 
-                                const selection = observable.box<Location | undefined>(undefined, { deep: false });
+                                const selection = observable.box<StackFrame | undefined>(undefined, { deep: false });
                                 selection.observe(change => {
-                                    const location = change.newValue;
-                                    postSelectArtifact(result, location?.physicalLocation);
+                                    const frame = change.newValue;
+                                    postSelectArtifact(result, frame?.location?.physicalLocation);
                                 });
                                 if (stack.message?.text) {
                                     return <div key={key} className="svStack">

--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -151,7 +151,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                                     <span className="svSecondary">No stacks in selected result.</span>
                                 </div>;
 
-                            return this.stacks.map(stack => {
+                            return this.stacks.map((stack, key) => {
                                 const stackFrames = stack.frames;
 
                                 const selection = observable.box<Location | undefined>(undefined, { deep: false });
@@ -160,7 +160,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                                     postSelectArtifact(result, location?.physicalLocation);
                                 });
                                 if (stack.message?.text) {
-                                    return <div className="svStack">
+                                    return <div key={key} className="svStack">
                                         <div className="svStacksMessage">
                                             {stack?.message?.text}
                                         </div>


### PR DESCRIPTION
The `selection` observer for the stack frame list receives an `IValueDidChange<StackFrame | undefined>` but the code assumes the callback argument to be an `IValueDidChange<Location | undefined>`, which prevents the user from clicking a stack frame to inspect it since `location?.physicalLocation` will always be `undefined`.

This PR should fix the issue.