### PR TITLE
Improve decorations

### DIFF
--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -6,15 +6,21 @@ import jsonMap from 'json-source-map';
 import { autorun, IArraySplice, observable, observe } from 'mobx';
 import { Log, Region, Result } from 'sarif';
 import { commands, ExtensionContext, TextEditorRevealType, Uri, ViewColumn, WebviewPanel, window, workspace } from 'vscode';
-import { filtersColumn, filtersRow, JsonMap, PanelToExtensionMessage, ResultId } from '../shared';
+import { filtersColumn, filtersRow, JsonMap, PanelToExtensionMessage } from '../shared';
 import { loadLogs } from './loadLogs';
 import { regionToSelection } from './regionToSelection';
 import { Store } from './store';
 import { UriRebaser } from './uriRebaser';
 
+interface IPanelSelection {
+    result: Result;
+    uri: string;
+}
+
 export class Panel {
     private title = 'SARIF Result'
     @observable private panel: WebviewPanel | null = null
+    selection = observable.box<IPanelSelection | null>(null, { deep: false })
 
     constructor(
         readonly context: Pick<ExtensionContext, 'extensionPath' | 'subscriptions'>,
@@ -110,10 +116,13 @@ export class Panel {
                     break;
                 }
                 case 'select': {
-                    const {logUri, uri, region} = message;
+                    const { id, uri, region } = message;
+                    const [logUri, runIndex, resultIndex] = id;
                     const validatedUri = await basing.translateArtifactToLocal(uri);
                     if (!validatedUri) return;
                     await this.selectLocal(logUri, validatedUri, region);
+                    const result = store.logs.find(log => log._uri === logUri)?.runs?.[runIndex]?.results?.[resultIndex];
+                    this.selection.set(result ? { result, uri: validatedUri } : null);
                     break;
                 }
                 case 'selectLog': {

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -136,11 +136,9 @@ export async function postSelectArtifact(result: Result, ploc?: PhysicalLocation
     if (!isActive()) return;
 
     if (!ploc) return;
-    const log = result._log;
-    const logUri = log._uri;
     const [uri, uriContent] = parseArtifactLocation(result, ploc?.artifactLocation);
     const region = ploc?.region;
-    await vscode.postMessage({ command: 'select', logUri, uri: uriContent ?? uri, region });
+    await vscode.postMessage({ command: 'select', id: result._id, uri: uriContent ?? uri, region });
 }
 
 export async function postSelectLog(result: Result) {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -258,7 +258,7 @@ interface ICloseAllLogsMessage {
 
 interface ISelectMessage {
     command: 'select';
-    logUri: string;
+    id: ResultId;
     uri: string;
     region: Region;
 }


### PR DESCRIPTION
This PR should fix #441, #442 and #443. I added `selection` observable to the `Panel` class to keep track of the result in the main extension component. The decorations are now set by an observer instead of the code actions provider. Unfortunately, the logic for finding the relevant document for an artifact location is a bit fragile. If you have any suggestions, I would like to hear them.