### PR TITLE
Analysis Steps improvements and other improvements.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sarif-viewer",
-    "version": "3.1.2",
+    "version": "3.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sarif-viewer",
-            "version": "3.1.2",
+            "version": "3.2.0",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "1.14.8",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
         "start": "webpack --watch --mode development",
         "server": "webpack serve --mode development",
         "test": "mocha",
-        "testcoverage": "nyc mocha --watch=false",
+        "test:watch": "mocha --watch",
+        "testcoverage": "nyc mocha",
         "package": "vsce package",
         "vscode:prepublish": "webpack --mode production",
         "lint": "eslint src"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Adds support for viewing SARIF logs",
     "author": "Microsoft Corporation",
     "license": "MIT",
-    "version": "3.1.2",
+    "version": "3.2.0",
     "publisher": "MS-SarifVSCode",
     "repository": {
         "type": "git",

--- a/src/extension/index.activateDecorations.ts
+++ b/src/extension/index.activateDecorations.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+/* eslint-disable filenames/match-regex */
+
+import { IArraySplice, observe } from 'mobx';
+import { Log } from 'sarif';
+import { Disposable, languages, Range, ThemeColor, window } from 'vscode';
+import { parseArtifactLocation } from '../shared';
+import '../shared/extension';
+import { regionToSelection } from './regionToSelection';
+import { ResultDiagnostic } from './resultDiagnostic';
+import { Store } from './store';
+
+// Decorations are for Analysis Steps.
+export function activateDecorations(disposables: Disposable[], store: Store) {
+    const decorationTypeCallout = window.createTextEditorDecorationType({
+        after: { color: new ThemeColor('problemsWarningIcon.foreground') }
+    });
+    const decorationTypeHighlight = window.createTextEditorDecorationType({
+        border: '1px',
+        borderStyle: 'solid',
+        borderColor: new ThemeColor('problemsWarningIcon.foreground'),
+    });
+    disposables.push(languages.registerCodeActionsProvider('*', {
+        provideCodeActions: (doc, _range, context) => {
+            if (context.only) return;
+
+            const diagnostic = context.diagnostics[0] as ResultDiagnostic | undefined;
+            if (!diagnostic) return;
+
+            const result = diagnostic?.result;
+            if (!result) return; // Don't clear the decorations until the next result is selected.
+
+            const editor = window.visibleTextEditors.find(editor => editor.document === doc);
+            if (!editor) return; // When would editor be undef?
+
+            const locations = result.codeFlows?.[0]?.threadFlows?.[0]?.locations ?? [];
+
+            const docUriString = doc.uri.toString();
+            const locationsInDoc = locations.filter(tfl => {
+                const [artifactUriString] = parseArtifactLocation(result, tfl.location?.physicalLocation?.artifactLocation);
+                return docUriString === artifactUriString;
+            });
+
+            const messages = locationsInDoc.map((tfl) => {
+                const text = tfl.location?.message?.text;
+                return `Step ${locations.indexOf(tfl) + 1}${text ? `: ${text}` : ''}`;
+            });
+            const ranges = locationsInDoc.map(tfl => regionToSelection(doc, tfl.location?.physicalLocation?.region));
+            const rangesEnd = ranges.map(range => {
+                const endPos = doc.lineAt(range.end.line).range.end;
+                return new Range(endPos, endPos);
+            });
+            const rangesEndAdj = rangesEnd.map(range => {
+                const tabCount = doc.lineAt(range.end.line).text.match(/\t/g)?.length ?? 0;
+                const tabCharAdj = tabCount * (editor.options.tabSize as number - 1); // Intra-character tabs are counted wrong.
+                return range.end.character + tabCharAdj;
+            });
+            const maxRangeEnd = Math.max(...rangesEndAdj) + 2; // + for Padding
+            const decorCallouts = rangesEnd.map((range, i) => ({
+                range,
+                hoverMessage: messages[i],
+                renderOptions: { after: { contentText: ` ${'┄'.repeat(maxRangeEnd - rangesEndAdj[i])} ${messages[i]}`, } }, // ←
+            }));
+            editor.setDecorations(decorationTypeCallout, decorCallouts);
+            editor.setDecorations(decorationTypeHighlight, ranges);
+            return [];
+        }
+    }));
+    const disposer = observe(store.logs, change => {
+        const {removed} = change as unknown as IArraySplice<Log>;
+        if (!removed.length) return;
+        window.visibleTextEditors.forEach(editor => {
+            editor.setDecorations(decorationTypeCallout, []);
+            editor.setDecorations(decorationTypeHighlight, []);
+        });
+    });
+    disposables.push({ dispose: disposer });
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { IArraySplice, observe } from 'mobx';
-import { Log } from 'sarif';
-import { CancellationToken, commands, DiagnosticSeverity, Disposable, ExtensionContext, languages, Range, TextDocument, ThemeColor, Uri, window, workspace } from 'vscode';
+import { observe } from 'mobx';
+import { CancellationToken, commands, DiagnosticSeverity, Disposable, ExtensionContext, languages, TextDocument, Uri, window, workspace } from 'vscode';
 import { mapDistinct } from '../shared';
 import '../shared/extension';
+import { activateDecorations } from './index.activateDecorations';
 import { loadLogs } from './loadLogs';
 import { Panel } from './panel';
 import platformUriNormalize from './platformUriNormalize';
@@ -137,73 +137,6 @@ function activateWatchDocuments(disposables: Disposable[], store: Store, panel: 
         if (!doc.fileName.match(/\.sarif$/i)) return;
         store.logs.removeFirst(log => log._uri === doc.uri.toString());
     }));
-}
-
-// Decorations are for Call Trees.
-function activateDecorations(disposables: Disposable[], store: Store) {
-    const decorationTypeCallout = window.createTextEditorDecorationType({
-        after: { color: new ThemeColor('problemsWarningIcon.foreground') }
-    });
-    const decorationTypeHighlight = window.createTextEditorDecorationType({
-        border: '1px',
-        borderStyle: 'solid',
-        borderColor: new ThemeColor('problemsWarningIcon.foreground'),
-    });
-    disposables.push(languages.registerCodeActionsProvider('*', {
-        provideCodeActions: (doc, _range, context) => {
-            if (context.only) return;
-
-            const diagnostic = context.diagnostics[0] as ResultDiagnostic | undefined;
-            if (!diagnostic) return;
-
-            const result = diagnostic?.result;
-            if (!result) return; // Don't clear the decorations until the next result is selected.
-
-            const editor = window.visibleTextEditors.find(editor => editor.document === doc);
-            if (!editor) return; // When would editor be undef?
-
-            const locations = result.codeFlows?.[0]?.threadFlows?.[0]?.locations ?? [];
-
-            const docUriString = doc.uri.toString();
-            const locationsInDoc = locations.filter(tfl => {
-                const [artifactUriString] = parseArtifactLocation(result, tfl.location?.physicalLocation?.artifactLocation);
-                return docUriString === artifactUriString;
-            });
-
-            const messages = locationsInDoc.map((tfl) => {
-                const text = tfl.location?.message?.text;
-                return `Step ${locations.indexOf(tfl) + 1}${text ? `: ${text}` : ''}`;
-            });
-            const ranges = locationsInDoc.map(tfl => regionToSelection(doc, tfl.location?.physicalLocation?.region));
-            const rangesEnd = ranges.map(range => {
-                const endPos = doc.lineAt(range.end.line).range.end;
-                return new Range(endPos, endPos);
-            });
-            const rangesEndAdj = rangesEnd.map(range => {
-                const tabCount = doc.lineAt(range.end.line).text.match(/\t/g)?.length ?? 0;
-                const tabCharAdj = tabCount * (editor.options.tabSize as number - 1); // Intra-character tabs are counted wrong.
-                return range.end.character + tabCharAdj;
-            });
-            const maxRangeEnd = Math.max(...rangesEndAdj) + 2; // + for Padding
-            const decorCallouts = rangesEnd.map((range, i) => ({
-                range,
-                hoverMessage: messages[i],
-                renderOptions: { after: { contentText: ` ${'┄'.repeat(maxRangeEnd - rangesEndAdj[i])} ${messages[i]}`, } }, // ←
-            }));
-            editor.setDecorations(decorationTypeCallout, decorCallouts);
-            editor.setDecorations(decorationTypeHighlight, ranges);
-            return [];
-        }
-    }));
-    const disposer = observe(store.logs, change => {
-        const {removed} = change as unknown as IArraySplice<Log>;
-        if (!removed.length) return;
-        window.visibleTextEditors.forEach(editor => {
-            editor.setDecorations(decorationTypeCallout, []);
-            editor.setDecorations(decorationTypeHighlight, []);
-        });
-    });
-    disposables.push({ dispose: disposer });
 }
 
 function activateVirtualDocuments(disposables: Disposable[], store: Store) {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -163,11 +163,18 @@ function activateDecorations(disposables: Disposable[], store: Store) {
             if (!editor) return; // When would editor be undef?
 
             const locations = result.codeFlows?.[0]?.threadFlows?.[0]?.locations ?? [];
-            const messages = locations.map((tfl, i) => {
-                const text = tfl.location?.message?.text;
-                return `Step ${i + 1}${text ? `: ${text}` : ''}`;
+
+            const docUriString = doc.uri.toString();
+            const locationsInDoc = locations.filter(tfl => {
+                const [artifactUriString] = parseArtifactLocation(result, tfl.location?.physicalLocation?.artifactLocation);
+                return docUriString === artifactUriString;
             });
-            const ranges = locations.map(tfl => regionToSelection(doc, tfl.location?.physicalLocation?.region));
+
+            const messages = locationsInDoc.map((tfl) => {
+                const text = tfl.location?.message?.text;
+                return `Step ${locations.indexOf(tfl) + 1}${text ? `: ${text}` : ''}`;
+            });
+            const ranges = locationsInDoc.map(tfl => regionToSelection(doc, tfl.location?.physicalLocation?.region));
             const rangesEnd = ranges.map(range => {
                 const endPos = doc.lineAt(range.end.line).range.end;
                 return new Range(endPos, endPos);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -68,7 +68,7 @@ export async function activate(context: ExtensionContext) {
     }
 
     // API
-    return {
+    const api = {
         async openLogs(logs: Uri[], _options: unknown, cancellationToken?: CancellationToken) {
             store.logs.push(...await loadLogs(logs, cancellationToken));
             if (cancellationToken?.isCancellationRequested) return;
@@ -89,6 +89,11 @@ export async function activate(context: ExtensionContext) {
             baser.uriBases = values.map(uri => uri.toString());
         },
     };
+
+    // During development, use the following line to auto-load a log.
+    // api.openLogs([Uri.parse('/path/to/log.sarif')], {});
+
+    return api;
 }
 
 function activateDiagnostics(disposables: Disposable[], store: Store, baser: UriRebaser) {

--- a/src/extension/loadLogs.spec.ts
+++ b/src/extension/loadLogs.spec.ts
@@ -37,7 +37,10 @@ describe('loadLogs', () => {
             Uri,
             window: {
                 showWarningMessage: () => { },
-            }
+            },
+            workspace: {
+                workspaceFolders: undefined,
+            },
         },
         './telemetry': {
             activate: () => { },

--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -56,6 +56,7 @@ export class Panel {
             filtersColumn,
         };
         const state = Store.globalState.get('view', defaultState);
+        const workspaceUri = workspace.workspaceFolders?.[0]?.uri.toString();
         webview.html = `<!DOCTYPE html>
             <html lang="en">
             <head>
@@ -77,7 +78,7 @@ export class Panel {
                 <script>
                     vscode = acquireVsCodeApi();
                     (async () => {
-                        const store = new Store(${JSON.stringify(state)})
+                        const store = new Store(${JSON.stringify(state)}, ${workspaceUri ? `'${workspaceUri}'` : 'undefined'})
                         await store.onMessage({ data: ${JSON.stringify(this.createSpliceLogsMessage([], store.logs))} })
                         ReactDOM.render(
                             React.createElement(Index, { store }),

--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -120,8 +120,7 @@ export class Panel {
                 case 'selectLog': {
                     const [logUri, runIndex, resultIndex] = message.id as ResultId;
                     const log = store.logs.find(log => log._uri === logUri);
-                    const result = store.logs.find(log => log._uri === logUri)?.runs[runIndex]?.results?.[resultIndex];
-                    if (!log || !result) return;
+                    if (!log) return;
 
                     const logUriUpgraded = log._uriUpgraded ?? log._uri;
                     if (!log._jsonMap) {

--- a/src/extension/regionToSelection.ts
+++ b/src/extension/regionToSelection.ts
@@ -25,10 +25,13 @@ export function regionToSelection(doc: TextDocument, region: Region | undefined)
 
     if (startLine !== undefined) {
         const line = doc.lineAt(startLine - 1);
+
+        // Translate from Region (1-based) to Range (0-based).
         const minusOne = (n: number | undefined) => n === undefined ? undefined : n - 1;
+
         return new Selection(
             startLine - 1,
-            minusOne(region.startColumn) ?? line.firstNonWhitespaceCharacterIndex, // Trimming whitespace for default startColumn value.
+            Math.max(line.firstNonWhitespaceCharacterIndex, minusOne(region.startColumn) ?? 0), // Trim leading whitespace.
             (region.endLine ?? startLine) - 1,
             minusOne(region.endColumn) ?? Number.MAX_SAFE_INTEGER, // Arbitrarily large number representing the rest of the line.
         );

--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -20,8 +20,8 @@ type TabName = 'Info' | 'Analysis Steps';
 interface DetailsProps { result: Result, height: IObservableValue<number> }
 @observer export class Details extends Component<DetailsProps> {
     private selectedTab = observable.box<TabName>('Info')
-    @computed private get threadFlowLocations() {
-		return this.props.result?.codeFlows?.[0]?.threadFlows?.[0].locations;
+    @computed private get threadFlowLocations(): ThreadFlowLocation[] {
+		return this.props.result?.codeFlows?.[0]?.threadFlows?.[0].locations ?? [];
 	}
     @computed private get stacks() {
         return this.props.result?.stacks;
@@ -29,7 +29,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
     constructor(props: DetailsProps) {
         super(props);
         autorun(() => {
-            const hasThreadFlows = !!this.threadFlowLocations?.length;
+            const hasThreadFlows = !!this.threadFlowLocations.length;
             this.selectedTab.set(hasThreadFlows ? 'Analysis Steps' : 'Info');
         });
     }
@@ -106,7 +106,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                         </div>
                     </div>
                 </Tab>
-                <Tab name="Analysis Steps" count={this.threadFlowLocations?.length || 0}>
+                <Tab name="Analysis Steps" count={this.threadFlowLocations.length}>
                     <div className="svDetailsBody svDetailsCodeflowAndStacks">
                         {(() => {
                             const renderThreadFlowLocation = (threadFlowLocation: ThreadFlowLocation) => {

--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -44,26 +44,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
 
         const {result, height} = this.props;
         const helpUri = result?._rule?.helpUri;
-        const renderThreadFlowLocation = (threadFlowLocation: ThreadFlowLocation) => {
-            const marginLeft = ((threadFlowLocation.nestingLevel ?? 1) - 1) * 24;
-            const { message, uri, region } = parseLocation(result, threadFlowLocation.location);
-            return <>
-                <div className="ellipsis" style={{ marginLeft }}>{message ?? '—'}</div>
-                <div className="svSecondary">{uri?.file ?? '—'}</div>
-                <div className="svLineNum">{region?.startLine}:{region?.startColumn ?? 1}</div>
-            </>;
-        };
-        const renderStack = (stackFrame: StackFrame) => {
-            const location = stackFrame.location;
-            const logicalLocation = stackFrame.location?.logicalLocations?.[0];
-            const { message, uri, region } = parseLocation(result, location);
-            const text = `${message ?? ''} ${logicalLocation?.fullyQualifiedName ?? ''}`;
-            return <>
-                <div className="ellipsis">{text ?? '—'}</div>
-                <div className="svSecondary">{uri?.file ?? '—'}</div>
-                <div className="svLineNum">{region?.startLine}:1</div>
-            </>;
-        };
+
         return <div className="svDetailsPane" style={{ height: height.get() }}>
             {result && <TabPanel selection={this.selectedTab}>
                 <Tab name="Info">
@@ -130,6 +111,16 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                         {(() => {
                             const items = this.threadFlowLocations;
 
+                            const renderThreadFlowLocation = (threadFlowLocation: ThreadFlowLocation) => {
+                                const marginLeft = ((threadFlowLocation.nestingLevel ?? 1) - 1) * 24;
+                                const { message, uri, region } = parseLocation(result, threadFlowLocation.location);
+                                return <>
+                                    <div className="ellipsis" style={{ marginLeft }}>{message ?? '—'}</div>
+                                    <div className="svSecondary">{uri?.file ?? '—'}</div>
+                                    <div className="svLineNum">{region?.startLine}:{region?.startColumn ?? 1}</div>
+                                </>;
+                            };
+
                             const selection = observable.box<ThreadFlowLocation | undefined>(undefined, { deep: false });
                             selection.observe(change => {
                                 const threadFlowLocation = change.newValue;
@@ -149,6 +140,18 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                                 return <div className="svZeroData">
                                     <span className="svSecondary">No stacks in selected result.</span>
                                 </div>;
+
+                            const renderStack = (stackFrame: StackFrame) => {
+                                const location = stackFrame.location;
+                                const logicalLocation = stackFrame.location?.logicalLocations?.[0];
+                                const { message, uri, region } = parseLocation(result, location);
+                                const text = `${message ?? ''} ${logicalLocation?.fullyQualifiedName ?? ''}`;
+                                return <>
+                                    <div className="ellipsis">{text ?? '—'}</div>
+                                    <div className="svSecondary">{uri?.file ?? '—'}</div>
+                                    <div className="svLineNum">{region?.startLine}:1</div>
+                                </>;
+                            };
 
                             return this.stacks.map(stack => {
                                 const stackFrames = stack.frames;

--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -109,8 +109,6 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                 <Tab name="Analysis Steps" count={this.threadFlowLocations?.length || 0}>
                     <div className="svDetailsBody svDetailsCodeflowAndStacks">
                         {(() => {
-                            const items = this.threadFlowLocations;
-
                             const renderThreadFlowLocation = (threadFlowLocation: ThreadFlowLocation) => {
                                 const marginLeft = ((threadFlowLocation.nestingLevel ?? 1) - 1) * 24;
                                 const { message, uri, region } = parseLocation(result, threadFlowLocation.location);
@@ -127,7 +125,7 @@ interface DetailsProps { result: Result, height: IObservableValue<number> }
                                 postSelectArtifact(result, threadFlowLocation?.location?.physicalLocation);
                             });
 
-                            return <List items={items} renderItem={renderThreadFlowLocation} selection={selection} allowClear>
+                            return <List items={this.threadFlowLocations} renderItem={renderThreadFlowLocation} selection={selection} allowClear>
                                 <span className="svSecondary">No analysis steps in selected result.</span>
                             </List>;
                         })()}

--- a/src/panel/index.scss
+++ b/src/panel/index.scss
@@ -72,6 +72,7 @@ mark {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-height: 20px; // Prevent the splitter from completely hiding the list pane.
 
     .svTable {
         flex: 1 1;

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -5,6 +5,7 @@ import { action, autorun, computed, intercept, observable, observe, toJS, when }
 import { Log, PhysicalLocation, ReportingDescriptor, Result } from 'sarif';
 import { augmentLog, CommandExtensionToPanel, filtersColumn, filtersRow, parseArtifactLocation, Visibility } from '../shared';
 import '../shared/extension';
+import { overrideBaseUri } from '../shared/overrideBaseUri';
 import { isActive } from './isActive';
 import { ResultTableStore } from './resultTableStore';
 import { Row, RowItem } from './tableStore';
@@ -12,7 +13,7 @@ import { Row, RowItem } from './tableStore';
 export class IndexStore {
     private driverlessRules = new Map<string, ReportingDescriptor>();
 
-    constructor(state: Record<string, Record<string, Record<string, Visibility>>>, defaultSelection?: boolean) {
+    constructor(state: Record<string, Record<string, Record<string, Visibility>>>, workspaceUri?: string, defaultSelection?: boolean) {
         this.filtersRow = state.filtersRow;
         this.filtersColumn = state.filtersColumn;
         const setState = () => {
@@ -31,7 +32,10 @@ export class IndexStore {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         intercept(this.logs, (change: any) => {
             if (change.type !== 'splice') throw new Error(`Unexpected change type. ${change.type}`);
-            change.added.forEach((log: Log) => augmentLog(log, this.driverlessRules));
+            change.added.forEach((log: Log) => {
+                overrideBaseUri(log, workspaceUri);
+                augmentLog(log, this.driverlessRules);
+            });
             return change;
         });
 

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -3,7 +3,7 @@
 
 import { action, autorun, computed, intercept, observable, observe, toJS, when } from 'mobx';
 import { Log, PhysicalLocation, ReportingDescriptor, Result } from 'sarif';
-import { augmentLog, CommandExtensionToPanel, filtersColumn, filtersRow, parseArtifactLocation, Visibility } from '../shared';
+import { augmentLog, CommandExtensionToPanel, filtersColumn, filtersRow, findResult, parseArtifactLocation, Visibility } from '../shared';
 import '../shared/extension';
 import { overrideBaseUri } from '../shared/overrideBaseUri';
 import { isActive } from './isActive';
@@ -108,8 +108,7 @@ export class IndexStore {
             if (!id) {
                 this.selection.set(undefined);
             } else {
-                const [logUri, runIndex, resultIndex] = id;
-                const result = this.logs.find(log => log._uri === logUri)?.runs[runIndex]?.results?.[resultIndex];
+                const result = findResult(this.logs, id);
                 if (!result) throw new Error('Unexpected: result undefined');
                 this.selectedTab.get().store?.select(result);
             }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -11,6 +11,11 @@ export type JsonMap = Record<string, JsonRange>
 
 export type ResultId = [string, number, number]
 
+export function findResult(logs: Log[], id: ResultId): Result | undefined {
+    const [logUri, runIndex, resultIndex] = id;
+    return logs.find(log => log._uri === logUri)?.runs[runIndex]?.results?.[resultIndex];
+}
+
 // The extended members we're adding here are prefixed with an underscore.
 // Using this marker to easily get a sense of how much we're depending on these extended members.
 // Once this design stabilities, these underscores will likely be removed as

--- a/src/shared/overrideBaseUri.spec.ts
+++ b/src/shared/overrideBaseUri.spec.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'assert';
+import { Log } from 'sarif';
+import { overrideBaseUri } from './overrideBaseUri';
+
+describe('overrideBaseUri', () => {
+    function createBasicLog(): Log {
+        return {
+            runs: [
+                {
+                    originalUriBaseIds: {
+                        SRCROOT_1: {
+                            uri: 'file:///var/jenkins_home/workspace/org/workflow/project/1/',
+                        },
+                        SRCROOT_2: {
+                            uri: 'file:///var/jenkins_home/workspace/org/workflow/project/2/',
+                        },
+                    },
+                },
+                {
+                    originalUriBaseIds: {
+                        SRCROOT_3: {
+                            uri: 'file:///var/jenkins_home/workspace/org/workflow/project/1/',
+                        },
+                        SRCROOT_4: {
+                            uri: 'file:///var/jenkins_home/workspace/org/workflow/project/2/',
+                        },
+                    },
+                },
+            ],
+        } as unknown as Log;
+    }
+
+    it('overrides all originalUriBaseIds uri values (most common case)', async () => {
+        const log = createBasicLog();
+        const newBaseUri = 'file:///path/to/project';
+        overrideBaseUri(log, newBaseUri);
+        assert.strictEqual(log.runs![0].originalUriBaseIds!.SRCROOT_1.uri, newBaseUri);
+        assert.strictEqual(log.runs![0].originalUriBaseIds!.SRCROOT_2.uri, newBaseUri);
+        assert.strictEqual(log.runs![1].originalUriBaseIds!.SRCROOT_3.uri, newBaseUri);
+        assert.strictEqual(log.runs![1].originalUriBaseIds!.SRCROOT_4.uri, newBaseUri);
+    });
+
+    it('does not throw if log has no runs', async () => {
+        overrideBaseUri({} as Log, 'file:///path/to/project');
+    });
+
+    it('does not throw if newBaseUri is undefined', async () => {
+        overrideBaseUri(createBasicLog(), undefined);
+    });
+
+    it('does not throw if newBaseUri is empty', async () => {
+        overrideBaseUri(createBasicLog(), '');
+    });
+});

--- a/src/shared/overrideBaseUri.ts
+++ b/src/shared/overrideBaseUri.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Log } from 'sarif';
+
+export function overrideBaseUri(log: Log, newBaseUri: string | undefined): void {
+    if (!newBaseUri) return;
+    for (const run of log.runs ?? []) {
+        const originalUriBaseIds = run.originalUriBaseIds ?? {};
+        for (const id of Object.keys(originalUriBaseIds)) {
+            originalUriBaseIds[id].uri = newBaseUri;
+        }
+    }
+}


### PR DESCRIPTION
Note: I recommend reviewing by commit rather than the cumulatively.

The largest change is with Analysis Steps (Thread Flows). Previously flows were constrained to a single document. Now if you select a multi-document flow, and happen to have several documents open, you will see the decorations simultaneously light up. Indentation was also added to the Analysis Steps list to help visualize stack depth. Especially useful in long flows.

The next largest change better leveraging base URIs. This should offer an improved experience (less "Locate file..." dialogs) for one of our most common cases: where the Log contains base URIs and the user has a corresponding workspace open.

A few more changes are incoming, but I wanted to get a head start on the review process.