### PR TITLE
Block inline scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sarif-viewer",
-    "version": "3.2.0",
+    "version": "3.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sarif-viewer",
-            "version": "3.2.0",
+            "version": "3.2.2",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "1.14.8",
@@ -44,6 +44,7 @@
                 "@typescript-eslint/eslint-plugin": "3.1.0",
                 "@typescript-eslint/parser": "3.1.0",
                 "@zeit/ncc": "0.22.1",
+                "copy-webpack-plugin": "^9.1.0",
                 "css-loader": "^6.3.0",
                 "eslint": "7.1.0",
                 "eslint-plugin-filenames": "1.3.2",
@@ -2562,6 +2563,42 @@
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
         },
+        "node_modules/copy-webpack-plugin": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+            "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
+            "dev": true,
+            "dependencies": {
+                "fast-glob": "^3.2.7",
+                "glob-parent": "^6.0.1",
+                "globby": "^11.0.3",
+                "normalize-path": "^3.0.0",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            }
+        },
+        "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3878,15 +3915,15 @@
             "peer": true
         },
         "node_modules/fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -3896,7 +3933,7 @@
                 "micromatch": "^4.0.4"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=8.6.0"
             }
         },
         "node_modules/fast-json-stable-stringify": {
@@ -4875,9 +4912,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -5262,9 +5299,9 @@
             }
         },
         "node_modules/is-glob": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -13325,6 +13362,31 @@
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
         },
+        "copy-webpack-plugin": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+            "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
+            "dev": true,
+            "requires": {
+                "fast-glob": "^3.2.7",
+                "glob-parent": "^6.0.1",
+                "globby": "^11.0.3",
+                "normalize-path": "^3.0.0",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.3"
+                    }
+                }
+            }
+        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -14365,15 +14427,15 @@
             "peer": true
         },
         "fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
         "fast-glob": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -15167,9 +15229,9 @@
             "requires": {}
         },
         "ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
             "dev": true
         },
         "immutable": {
@@ -15453,9 +15515,9 @@
             "dev": true
         },
         "is-glob": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Adds support for viewing SARIF logs",
     "author": "Microsoft Corporation",
     "license": "MIT",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "publisher": "MS-SarifVSCode",
     "repository": {
         "type": "git",
@@ -110,6 +110,7 @@
         "@typescript-eslint/eslint-plugin": "3.1.0",
         "@typescript-eslint/parser": "3.1.0",
         "@zeit/ncc": "0.22.1",
+        "copy-webpack-plugin": "^9.1.0",
         "css-loader": "^6.3.0",
         "eslint": "7.1.0",
         "eslint-plugin-filenames": "1.3.2",

--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -49,14 +49,15 @@ export class Panel {
         );
         this.panel.onDidDispose(() => this.panel = null);
 
-        const src = Uri.file(`${context.extensionPath}/out/panel.js`);
+        const srcPanel = Uri.file(`${context.extensionPath}/out/panel.js`);
+        const srcInit = Uri.file(`${context.extensionPath}/out/init.js`);
         const defaultState = {
             version: 0,
             filtersRow,
             filtersColumn,
         };
-        const state = Store.globalState.get('view', defaultState);
-        const workspaceUri = workspace.workspaceFolders?.[0]?.uri.toString();
+
+        // JSON.stringify emits double quotes. To not conflict, certain attribute values use single quotes.
         webview.html = `<!DOCTYPE html>
             <html lang="en">
             <head>
@@ -65,27 +66,20 @@ export class Panel {
                     default-src 'none';
                     connect-src vscode-resource:;
                     font-src    vscode-resource:;
-                    script-src  vscode-resource: 'unsafe-inline';
+                    script-src  vscode-resource:;
                     style-src   vscode-resource: 'unsafe-inline';
                     ">
+                <meta name="storeState"        content='${JSON.stringify(Store.globalState.get('view', defaultState))}'>
+                <meta name="storeWorkspaceUri" content="${workspace.workspaceFolders?.[0]?.uri.toString() ?? ''}">
+                <meta name="spliceLogsMessage" content='${JSON.stringify(this.createSpliceLogsMessage([], store.logs))}'>
                 <style>
                     code { font-family: ${workspace.getConfiguration('editor').get('fontFamily')} }
                 </style>
             </head>
             <body>
                 <div id="root"></div>
-                <script src="${webview.asWebviewUri(src).toString()}"></script>
-                <script>
-                    vscode = acquireVsCodeApi();
-                    (async () => {
-                        const store = new Store(${JSON.stringify(state)}, ${workspaceUri ? `'${workspaceUri}'` : 'undefined'})
-                        await store.onMessage({ data: ${JSON.stringify(this.createSpliceLogsMessage([], store.logs))} })
-                        ReactDOM.render(
-                            React.createElement(Index, { store }),
-                            document.getElementById('root'),
-                        )
-                    })();
-                </script>
+                <script src="${webview.asWebviewUri(srcPanel).toString()}"></script>
+                <script src="${webview.asWebviewUri(srcInit).toString()}"></script>
             </body>
             </html>`;
 

--- a/src/panel/init.js
+++ b/src/panel/init.js
@@ -1,0 +1,17 @@
+vscode = acquireVsCodeApi();
+(async () => {
+    function getMetaContent(name) {
+        // We assert the meta name exists as they are hardcoded in the `webview.html`.
+        return document.querySelector(`meta[name="${name}"]`).content
+    }
+
+    const store = new Store(
+        JSON.parse(getMetaContent('storeState')),
+        getMetaContent('storeWorkspaceUri') || undefined,
+    )
+    await store.onMessage({ data: JSON.parse(getMetaContent('spliceLogsMessage')) })
+    ReactDOM.render(
+        React.createElement(Index, { store }),
+        document.getElementById('root'),
+    )
+})();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+const CopyPlugin = require("copy-webpack-plugin");
 const outputPath = require('path').join(__dirname, 'out');
 
 const common = {
@@ -71,6 +72,11 @@ module.exports = [
             maxAssetSize: 400 * 1024,
             maxEntrypointSize: 400 * 1024,
         },
+        plugins: [
+            new CopyPlugin({
+                patterns: [ 'src/panel/init.js' ],
+            }),
+        ],
     },
     {
         ...common,


### PR DESCRIPTION
Mitigating potential malicious SARIF Log embedded links. Addressing this by removing "unsafe-line" on the meta CSP. "Inline" in this context means not only links, but also script blocks. This eliminates a range of attack vectors.

The downstream effect is that one of our our own inline script blocks needs to be externalized (into `init.js`). Externalizing it requires some changes to the packaging settings. Thus this PR affects more files than you would imagine.
