### PR TITLE
Watch files opened via API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
                 "tslint": "5.12.1",
                 "typescript": "3.8.3",
                 "vsce": "^1.100.0",
-                "webpack": "^5.53.0",
+                "webpack": "^5.75.0",
                 "webpack-cli": "^4.8.0",
                 "webpack-dev-server": "^4.2.1"
             },
@@ -859,9 +859,9 @@
             "integrity": "sha512-uw8eYMIReOwstQ0QKF0sICefSy8cNO/v7gOTiIy9SbwuHyEecJUm7qlgueOO5S1udZ5I/irVydHVwMchgzbKTg=="
         },
         "node_modules/@types/eslint": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-            "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+            "version": "8.4.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+            "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -869,9 +869,9 @@
             }
         },
         "node_modules/@types/eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+            "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
             "dev": true,
             "dependencies": {
                 "@types/eslint": "*",
@@ -885,9 +885,9 @@
             "dev": true
         },
         "node_modules/@types/estree": {
-            "version": "0.0.50",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
         },
         "node_modules/@types/follow-redirects": {
@@ -1393,9 +1393,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-            "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -3238,6 +3238,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
             "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.0",
@@ -3251,6 +3252,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
             "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -3262,9 +3264,9 @@
             }
         },
         "node_modules/domelementtype": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "funding": [
                 {
                     "type": "github",
@@ -3273,20 +3275,24 @@
             ]
         },
         "node_modules/domhandler": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
-            "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dependencies": {
-                "domelementtype": "^2.0.1"
+                "domelementtype": "^2.3.0"
             },
             "engines": {
                 "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
         },
         "node_modules/domutils": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
             "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
             "dependencies": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -3300,6 +3306,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
             "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+            "dev": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -3367,9 +3374,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-            "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+            "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -3382,7 +3389,8 @@
         "node_modules/entities": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-            "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+            "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+            "dev": true
         },
         "node_modules/env-paths": {
             "version": "2.2.1",
@@ -3441,9 +3449,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-            "integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
             "dev": true
         },
         "node_modules/es-to-primitive": {
@@ -4639,9 +4647,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
         },
         "node_modules/growl": {
@@ -4824,25 +4832,68 @@
             "dev": true
         },
         "node_modules/html-to-react": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.2.tgz",
-            "integrity": "sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
+            "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
             "dependencies": {
-                "domhandler": "^3.0",
-                "htmlparser2": "^4.0",
-                "lodash.camelcase": "^4.3.0",
-                "ramda": "^0.26"
+                "domhandler": "^5.0",
+                "htmlparser2": "^8.0",
+                "lodash.camelcase": "^4.3.0"
             }
         },
         "node_modules/htmlparser2": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-            "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+            "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^3.0.0",
-                "domutils": "^2.0.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "entities": "^4.3.0"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/domutils": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/entities": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/http-deceiver": {
@@ -5859,19 +5910,11 @@
                 "node": ">=4"
             }
         },
-        "node_modules/json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
-        },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/json-schema": {
             "version": "0.2.3",
@@ -6305,9 +6348,9 @@
             }
         },
         "node_modules/micromark/node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -8205,11 +8248,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ramda": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-            "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
-        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8285,7 +8323,6 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
             "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
-            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^3.0.3",
                 "@types/unist": "^2.0.3",
@@ -10481,9 +10518,9 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "node_modules/watchpack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-            "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
             "dev": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
@@ -10508,35 +10545,35 @@
             "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "node_modules/webpack": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
-            "integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
+            "version": "5.75.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
             "dev": true,
             "dependencies": {
-                "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.50",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
-                "acorn": "^8.4.1",
+                "acorn": "^8.7.1",
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.8.0",
-                "es-module-lexer": "^0.7.1",
+                "enhanced-resolve": "^5.10.0",
+                "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.4",
-                "json-parse-better-errors": "^1.0.2",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
-                "watchpack": "^2.2.0",
-                "webpack-sources": "^3.2.0"
+                "watchpack": "^2.4.0",
+                "webpack-sources": "^3.2.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -10893,9 +10930,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-            "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
@@ -11980,9 +12017,9 @@
             "integrity": "sha512-uw8eYMIReOwstQ0QKF0sICefSy8cNO/v7gOTiIy9SbwuHyEecJUm7qlgueOO5S1udZ5I/irVydHVwMchgzbKTg=="
         },
         "@types/eslint": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-            "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+            "version": "8.4.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+            "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -11990,9 +12027,9 @@
             }
         },
         "@types/eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+            "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
             "dev": true,
             "requires": {
                 "@types/eslint": "*",
@@ -12006,9 +12043,9 @@
             "dev": true
         },
         "@types/estree": {
-            "version": "0.0.50",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
         },
         "@types/follow-redirects": {
@@ -12480,9 +12517,9 @@
             }
         },
         "acorn": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-            "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true
         },
         "acorn-import-assertions": {
@@ -13951,6 +13988,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
             "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+            "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.0",
@@ -13961,6 +13999,7 @@
                     "version": "4.2.2",
                     "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
                     "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+                    "dev": true,
                     "requires": {
                         "domelementtype": "^2.2.0"
                     }
@@ -13968,22 +14007,23 @@
             }
         },
         "domelementtype": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
         },
         "domhandler": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
-            "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "requires": {
-                "domelementtype": "^2.0.1"
+                "domelementtype": "^2.3.0"
             }
         },
         "domutils": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
             "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
             "requires": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -13994,6 +14034,7 @@
                     "version": "4.2.2",
                     "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
                     "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+                    "dev": true,
                     "requires": {
                         "domelementtype": "^2.2.0"
                     }
@@ -14054,9 +14095,9 @@
             }
         },
         "enhanced-resolve": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-            "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+            "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.4",
@@ -14066,7 +14107,8 @@
         "entities": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-            "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+            "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+            "dev": true
         },
         "env-paths": {
             "version": "2.2.1",
@@ -14113,9 +14155,9 @@
             }
         },
         "es-module-lexer": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-            "integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
             "dev": true
         },
         "es-to-primitive": {
@@ -15070,9 +15112,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
         },
         "growl": {
@@ -15219,25 +15261,51 @@
             "dev": true
         },
         "html-to-react": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.2.tgz",
-            "integrity": "sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
+            "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
             "requires": {
-                "domhandler": "^3.0",
-                "htmlparser2": "^4.0",
-                "lodash.camelcase": "^4.3.0",
-                "ramda": "^0.26"
+                "domhandler": "^5.0",
+                "htmlparser2": "^8.0",
+                "lodash.camelcase": "^4.3.0"
             }
         },
         "htmlparser2": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-            "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+            "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
             "requires": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^3.0.0",
-                "domutils": "^2.0.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "entities": "^4.3.0"
+            },
+            "dependencies": {
+                "dom-serializer": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+                    "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+                    "requires": {
+                        "domelementtype": "^2.3.0",
+                        "domhandler": "^5.0.2",
+                        "entities": "^4.2.0"
+                    }
+                },
+                "domutils": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+                    "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+                    "requires": {
+                        "dom-serializer": "^2.0.0",
+                        "domelementtype": "^2.3.0",
+                        "domhandler": "^5.0.1"
+                    }
+                },
+                "entities": {
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+                    "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+                }
             }
         },
         "http-deceiver": {
@@ -16015,19 +16083,11 @@
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
-        "json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
-        },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "json-schema": {
             "version": "0.2.3",
@@ -16376,9 +16436,9 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "requires": {
                         "ms": "2.1.2"
                     }
@@ -17843,11 +17903,6 @@
             "dev": true,
             "optional": true,
             "peer": true
-        },
-        "ramda": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-            "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
         },
         "randombytes": {
             "version": "2.1.0",
@@ -19643,9 +19698,9 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "watchpack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-            "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
             "dev": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
@@ -19667,35 +19722,35 @@
             "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "webpack": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
-            "integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
+            "version": "5.75.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
             "dev": true,
             "requires": {
-                "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.50",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
-                "acorn": "^8.4.1",
+                "acorn": "^8.7.1",
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.8.0",
-                "es-module-lexer": "^0.7.1",
+                "enhanced-resolve": "^5.10.0",
+                "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.4",
-                "json-parse-better-errors": "^1.0.2",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
-                "watchpack": "^2.2.0",
-                "webpack-sources": "^3.2.0"
+                "watchpack": "^2.4.0",
+                "webpack-sources": "^3.2.3"
             }
         },
         "webpack-cli": {
@@ -19918,9 +19973,9 @@
             }
         },
         "webpack-sources": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-            "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true
         },
         "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
         "tslint": "5.12.1",
         "typescript": "3.8.3",
         "vsce": "^1.100.0",
-        "webpack": "^5.53.0",
+        "webpack": "^5.75.0",
         "webpack-cli": "^4.8.0",
         "webpack-dev-server": "^4.2.1"
     },

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -200,13 +200,13 @@ function activateVirtualDocuments(disposables: Disposable[], store: Store) {
             if (contents?.rendered?.text) return contents?.rendered?.text;
             if (contents?.text) return contents?.text;
             if (contents?.binary) {
-                const lines = Buffer.from(contents?.binary, 'base64').toString('hex').match(/.{1,32}/g) ?? [];
-                return lines.reduce((sum, line, i) => {
+                const lines = Buffer.from(contents?.binary, 'base64').toString('hex').match(/.{1,32}/g);
+                return lines?.reduce((sum, line, i) => {
                     const lineNo = ((i + 128) * 16).toString(16).toUpperCase().padStart(8, '0');
                     // eslint-disable-next-line no-control-regex
                     const preview = Buffer.from(line, 'hex').toString('utf8').replace(/(\x09|\x0A|\x0B|\x0C|\x0D|\x1B)/g, '?');
                     return `${sum}${lineNo}  ${line.toUpperCase().match(/.{1,2}/g)?.join(' ')}  ${preview}\n`;
-                }, '');
+                }, '') ?? '';
             }
             token.isCancellationRequested = true;
             return '';

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -70,6 +70,13 @@ export async function activate(context: ExtensionContext) {
 
     // For now, we keep file watch functionality limited to the API.
     // After we're sure it's working well, consider also enabling it for files opened manually.
+    // FIXME: Possible race condition if a file is changed multiple times in quick succession.
+    // 1. First change event fires (denoted as [1]).
+    // 2. [1] Log is removed from the store.
+    // 3. Second change event fires (denoted as [2]).
+    // 4. [2] Log is removed from the store (returns false as it's already been removed).
+    // 5. [1] Log is re-loaded and added to the store.
+    // 6. [2] Log is re-loaded and added (again!) to the store.
     const watcher = watch([], {
         ignoreInitial: true
     }).on('change', async path => {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -75,6 +75,8 @@ export async function activate(context: ExtensionContext) {
     }).on('change', async path => {
         store.logs.removeFirst(log => log._uri === Uri.file(path).toString());
         store.logs.push(...await loadLogs([Uri.file(path)]));
+    }).on('unlink', path => {
+        store.logs.removeFirst(log => log._uri === Uri.file(path).toString());
     });
     disposables.push(new Disposable(() => watcher.close()));
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -78,7 +78,7 @@ export async function activate(context: ExtensionContext) {
     }).on('unlink', path => {
         store.logs.removeFirst(log => log._uri === Uri.file(path).toString());
     });
-    disposables.push(new Disposable(() => watcher.close()));
+    disposables.push(new Disposable(async () => await watcher.close()));
 
     // API
     const api = {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -95,6 +95,7 @@ export async function activate(context: ExtensionContext) {
             }
         },
         async closeAllLogs() {
+            watcher.unwatch('**/*');
             store.logs.splice(0);
         },
         get uriBases() {


### PR DESCRIPTION
Implements & closes #467.

This is a very simple file-watching implementation - for every log opened via `api.openLogs()`, we'll add it to a file watcher. When those files change (or are deleted), we'll update the SARIF Viewer as appropriate. We'll remove the files from the watcher once they're closed.

What I don't know is how chokidar handles multiple `add` calls for the same file - will it start watching the same file _twice_? Or is it smart enough to know that it's already watching and no-op? I don't have an easy way to test that scenario, but I'm hoping it's a pretty rare edge case for someone to repeatedly `openLogs` on a file that's already open.

I've tested this locally and confirmed that the openLogs implementation works, but not that closeLogs successfully removes from the watcher (though I'd be very surprised if it didn't).