### PR TITLE
Feature: download the source file from github if available

### DIFF
--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -124,7 +124,13 @@ export class Panel {
                 }
                 case 'select': {
                     const {logUri, uri, region} = message as { logUri: string, uri: string, region: Region};
-                    const validatedUri = await basing.translateArtifactToLocal(uri);
+                    const [_, runIndex, resultIndex] = message.id as ResultId;
+
+                    const log = store.logs.find(log => log._uri === logUri);
+                    if (!log) return;
+
+                    const versionControlProvenance = log.runs[runIndex].versionControlProvenance;
+                    const validatedUri = await basing.translateArtifactToLocal(uri, versionControlProvenance);
                     if (!validatedUri) return;
                     await this.selectLocal(logUri, validatedUri, region);
                     break;

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -141,7 +141,7 @@ export class UriRebaser {
         if (!validatedUri && !this.activeInfoMessages.has(artifactUri)) {
             // download from internet by changeset
             if (versionControlProvenance !== undefined) {
-                let url = new URL(`${versionControlProvenance[0].repositoryUri}/${versionControlProvenance[0].revisionId}/${artifactUri.startsWith('file://') ? artifactUri.substring(7) : artifactUri}`);
+                const url = new URL(`${versionControlProvenance[0].repositoryUri}/${versionControlProvenance[0].revisionId}/${artifactUri.startsWith('file://') ? artifactUri.substring(7) : artifactUri}`);
                 if (url.hostname === 'github.com') {
                     url.hostname = 'raw.githubusercontent.com';
                 }
@@ -152,7 +152,7 @@ export class UriRebaser {
                 if (!fileName.startsWith(root))
                     return '';
 
-                const fileUrl = `file:\/\/\/${fileName.replace(/\\/g, '/')}`;
+                const fileUrl = `file:///${fileName.replace(/\\/g, '/')}`;
                 // check if the file was already downloaded
                 if (await uriExists(fileUrl))
                     return fileUrl;
@@ -174,21 +174,21 @@ export class UriRebaser {
                     if (choice === `Always from ${url.hostname}`) {
                         this.trustedSites.push(url.hostname);
                         workspace.getConfiguration(this.extensionName)
-                                 .update(this.trustedSourceSitesConfigSection, this.trustedSites, ConfigurationTarget.Global);
+                            .update(this.trustedSourceSitesConfigSection, this.trustedSites, ConfigurationTarget.Global);
                     }
                     // download the file
                     if (choice === 'Yes' || choice === `Always from ${url.hostname}`) {
                         const mkdirRecursive = async (dir: string) => {
                             return new Promise((resolve, reject) => {
-                              fs.mkdir(dir, { recursive: true }, (error) => {
-                                if (error) {
-                                  reject(error);
-                                } else {
-                                  resolve(undefined);
-                                }
-                              });
+                                fs.mkdir(dir, { recursive: true }, (error) => {
+                                    if (error) {
+                                        reject(error);
+                                    } else {
+                                        resolve(undefined);
+                                    }
+                                });
                             });
-                          }
+                        };
 
                         try {
                             const response = await fetch(url);
@@ -198,11 +198,11 @@ export class UriRebaser {
                             await fs.promises.writeFile(fileName, buffer);
 
                             const partsOld = splitUri(artifactUri);
-                            const partsNew = splitUri(`file:\/\/${fileName.replace(/\\/g, '/')}`);
+                            const partsNew = splitUri(`file://${fileName.replace(/\\/g, '/')}`);
                             this.updateBases(partsOld, partsNew);
                             return fileUrl;
                         }
-                        catch (error : any) {
+                        catch (error: any) {
                             await window.showErrorMessage(error.toString());
                             // continue with file open dialog
                         }

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -159,6 +159,7 @@ export class UriRebaser {
 
                 if (url.protocol === 'https:') {
                     let choice: string | undefined = 'Yes';
+                    const alwaysMsg = `Always from ${url.hostname}`;
                     // check if user marked this site as trusted to download always
                     if (!this.trustedSites.includes(url.hostname)) {
                         this.activeInfoMessages.add(artifactUri);
@@ -166,21 +167,21 @@ export class UriRebaser {
                             `Do you want to download the source file from this location?\n${url}`,
                             'Yes',
                             'No',
-                            `Always from ${url.hostname}`
+                            alwaysMsg
                         );
                         this.activeInfoMessages.delete(artifactUri);
                     }
                     // save the user preference to settings
-                    if (choice === `Always from ${url.hostname}`) {
+                    if (choice === alwaysMsg) {
                         this.trustedSites.push(url.hostname);
                         workspace.getConfiguration(this.extensionName)
                             .update(this.trustedSourceSitesConfigSection, this.trustedSites, ConfigurationTarget.Global);
                     }
                     // download the file
-                    if (choice === 'Yes' || choice === `Always from ${url.hostname}`) {
+                    if (choice === 'Yes' || choice === alwaysMsg) {
                         const mkdirRecursive = async (dir: string) => {
                             return new Promise((resolve, reject) => {
-                                fs.mkdir(dir, { recursive: true }, (error) => {
+                                fs.mkdir(dir, { recursive: true }, (error: any) => {
                                     if (error) {
                                         reject(error);
                                     } else {

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -148,12 +148,14 @@ export class UriRebaser {
 
                 // check for path traversal
                 const root = os.tmpdir().endsWith(path.sep) ? os.tmpdir() : `${os.tmpdir()}${path.sep}`;
-                let fileName = path.join(root, url.pathname).normalize();
+                const fileName = path.join(root, url.pathname).normalize();
                 if (!fileName.startsWith(root))
                     return '';
 
-                if (await uriExists(fileName))
-                    return `file:\/\/\/${fileName.replace(/\\/g, '/')}`;
+                const fileUrl = `file:\/\/\/${fileName.replace(/\\/g, '/')}`;
+                // check if the file was already downloaded
+                if (await uriExists(fileUrl))
+                    return fileUrl;
 
                 if (url.protocol === 'https:') {
                     let choice: string | undefined = 'Yes';
@@ -198,7 +200,7 @@ export class UriRebaser {
                             const partsOld = splitUri(artifactUri);
                             const partsNew = splitUri(`file:\/\/${fileName.replace(/\\/g, '/')}`);
                             this.updateBases(partsOld, partsNew);
-                            return `file:\/\/\/${fileName.replace(/\\/g, '/')}`;
+                            return fileUrl;
                         }
                         catch (error : any) {
                             await window.showErrorMessage(error.toString());

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -162,7 +162,7 @@ export async function postSelectArtifact(result: Result, ploc?: PhysicalLocation
     const logUri = log._uri;
     const [uri, uriContent] = parseArtifactLocation(result, ploc?.artifactLocation, overrideUriBase);
     const region = ploc?.region;
-    await vscode.postMessage({ command: 'select', logUri, uri: uriContent ?? uri, region });
+    await vscode.postMessage({ command: 'select', logUri, uri: uriContent ?? uri, region, id: result._id });
 }
 
 export async function postSelectLog(result: Result) {


### PR DESCRIPTION
Adds a feature similar to the already available in https://github.com/microsoft/sarif-visualstudio-extension - if the source file is not found, but `versionControlProvenance` is available, try to download the file from the source control server (works with github.com, not tested with others).