### PR TITLE
Update badge URLs in README.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @jeffersonking @GabeDeBacker @EasyRhinoMSFT
+*       @jeffersonking @GabeDeBacker @EasyRhinoMSFT @shaopeng-gh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![](https://vsmarketplacebadge.apphb.com/version-short/MS-SarifVSCode.sarif-viewer.svg)](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer)
-[![](https://vsmarketplacebadge.apphb.com/downloads-short/MS-SarifVSCode.sarif-viewer.svg)](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer)
+[![](https://vsmarketplacebadges.dev/version-short/MS-SarifVSCode.sarif-viewer.svg)](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer)
+[![](https://vsmarketplacebadges.dev/downloads-short/MS-SarifVSCode.sarif-viewer.svg)](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer)
 
 # SARIF Viewer for Visual Studio Code
 


### PR DESCRIPTION
SVGs are only allowed from a whitelisted domain. See https://code.visualstudio.com/api/references/extension-manifest#approved-badges