### PR TITLE
Honor extension-provided uriBase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sarif-viewer",
-    "version": "3.3.5",
+    "version": "3.3.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sarif-viewer",
-            "version": "3.3.5",
+            "version": "3.3.7",
             "license": "MIT",
             "dependencies": {
                 "@types/diff": "^5.0.2",
@@ -22,7 +22,6 @@
                 "react-markdown": "^5.0.3",
                 "semver": "7.3.2",
                 "tmp": "0.1.0",
-                "url-join": "4.0.1",
                 "vscode-codicons": "0.0.2",
                 "vscode-extension-telemetry": "0.1.6",
                 "vscode-uri": "2.1.2"
@@ -42,7 +41,6 @@
                 "@types/semver": "7.1.0",
                 "@types/sinon": "9.0.4",
                 "@types/tmp": "0.1.0",
-                "@types/url-join": "4.0.0",
                 "@types/vscode": "1.57",
                 "@typescript-eslint/eslint-plugin": "3.1.0",
                 "@typescript-eslint/parser": "3.1.0",
@@ -1043,12 +1041,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
-        },
-        "node_modules/@types/url-join": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.0.tgz",
-            "integrity": "sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==",
-            "dev": true
         },
         "node_modules/@types/vscode": {
             "version": "1.57.1",
@@ -10785,11 +10777,6 @@
                 "querystring": "0.2.0"
             }
         },
-        "node_modules/url-join": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
-        },
         "node_modules/url/node_modules/punycode": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -12693,12 +12680,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
-        },
-        "@types/url-join": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.0.tgz",
-            "integrity": "sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==",
-            "dev": true
         },
         "@types/vscode": {
             "version": "1.57.1",
@@ -20324,11 +20305,6 @@
                     "dev": true
                 }
             }
-        },
-        "url-join": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
         "@types/semver": "7.1.0",
         "@types/sinon": "9.0.4",
         "@types/tmp": "0.1.0",
-        "@types/url-join": "4.0.0",
         "@types/vscode": "1.57",
         "@typescript-eslint/eslint-plugin": "3.1.0",
         "@typescript-eslint/parser": "3.1.0",
@@ -202,7 +201,6 @@
         "react-markdown": "^5.0.3",
         "semver": "7.3.2",
         "tmp": "0.1.0",
-        "url-join": "4.0.1",
         "vscode-codicons": "0.0.2",
         "vscode-extension-telemetry": "0.1.6",
         "vscode-uri": "2.1.2"

--- a/src/extension/index.activateDecorations.ts
+++ b/src/extension/index.activateDecorations.ts
@@ -72,10 +72,9 @@ export function activateDecorations(disposables: Disposable[], store: Store, bas
             const currentDoc = editor.document;
             const locations = result.codeFlows?.[0]?.threadFlows?.[0]?.locations ?? [];
 
-            const docUriString = currentDoc.uri.toString();
             const locationsInDoc = locations.filter(async tfl => {
                 const [artifactUriString] = parseArtifactLocation(result, tfl.location?.physicalLocation?.artifactLocation);
-                return await baser.translateLocalToArtifact(docUriString) === artifactUriString;
+                return await baser.translateLocalToArtifact(currentDoc.uri) === artifactUriString;
             });
 
             const originalDoc = await getOriginalDoc(store.analysisInfo?.commit_sha, currentDoc);

--- a/src/extension/index.activateDecorations.ts
+++ b/src/extension/index.activateDecorations.ts
@@ -5,7 +5,7 @@
 import { diffChars } from 'diff';
 import { IArraySplice, observable, observe } from 'mobx';
 import { Log } from 'sarif';
-import { Disposable, languages, Range, ThemeColor, window, workspace } from 'vscode';
+import { Disposable, languages, Range, ThemeColor, window } from 'vscode';
 import { findResult, parseArtifactLocation, ResultId } from '../shared';
 import '../shared/extension';
 import { getOriginalDoc } from './getOriginalDoc';
@@ -73,8 +73,7 @@ export function activateDecorations(disposables: Disposable[], store: Store) {
 
             const docUriString = currentDoc.uri.toString();
             const locationsInDoc = locations.filter(tfl => {
-                const workspaceUri = workspace.workspaceFolders?.[0]?.uri.toString(); // TODO: Handle multiple workspaces.
-                const [artifactUriString] = parseArtifactLocation(result, tfl.location?.physicalLocation?.artifactLocation, workspaceUri);
+                const [artifactUriString] = parseArtifactLocation(result, tfl.location?.physicalLocation?.artifactLocation);
                 return docUriString === artifactUriString;
             });
 

--- a/src/extension/index.activateDecorations.ts
+++ b/src/extension/index.activateDecorations.ts
@@ -12,9 +12,10 @@ import { getOriginalDoc } from './getOriginalDoc';
 import { driftedRegionToSelection } from './regionToSelection';
 import { ResultDiagnostic } from './resultDiagnostic';
 import { Store } from './store';
+import { UriRebaser } from './uriRebaser';
 
 // Decorations are for Analysis Steps.
-export function activateDecorations(disposables: Disposable[], store: Store) {
+export function activateDecorations(disposables: Disposable[], store: Store, baser: UriRebaser) {
     // Navigating away from a diagnostic/result will not clear the `activeResultId`.
     // This keeps the decorations "pinned" while users navigate the thread flow steps.
     const activeResultId = observable.box<string | undefined>();
@@ -72,9 +73,9 @@ export function activateDecorations(disposables: Disposable[], store: Store) {
             const locations = result.codeFlows?.[0]?.threadFlows?.[0]?.locations ?? [];
 
             const docUriString = currentDoc.uri.toString();
-            const locationsInDoc = locations.filter(tfl => {
+            const locationsInDoc = locations.filter(async tfl => {
                 const [artifactUriString] = parseArtifactLocation(result, tfl.location?.physicalLocation?.artifactLocation);
-                return docUriString === artifactUriString;
+                return await baser.translateLocalToArtifact(docUriString) === artifactUriString;
             });
 
             const originalDoc = await getOriginalDoc(store.analysisInfo?.commit_sha, currentDoc);

--- a/src/extension/index.activateFixes.ts
+++ b/src/extension/index.activateFixes.ts
@@ -46,11 +46,11 @@ export function activateFixes(disposables: Disposable[], store: Pick<Store, 'ana
                 if (fix) {
                     const edit = new WorkspaceEdit();
                     for (const artifactChange of fix.artifactChanges) {
-                        const [uri, _uriContents] = parseArtifactLocation(result, artifactChange.artifactLocation);
+                        const [uri, uriBase] = parseArtifactLocation(result, artifactChange.artifactLocation);
                         const artifactUri = uri;
                         if (!artifactUri) continue;
 
-                        const localUri = await baser.translateArtifactToLocal(artifactUri);
+                        const localUri = await baser.translateArtifactToLocal(artifactUri, uriBase);
                         const currentDoc = await workspace.openTextDocument(Uri.parse(localUri, true /* Why true? */));
                         const originalDoc = await getOriginalDoc(store.analysisInfo?.commit_sha, currentDoc);
                         const diffBlocks = originalDoc ? diffChars(originalDoc.getText(), currentDoc.getText()) : [];

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -140,7 +140,7 @@ function activateDiagnostics(disposables: Disposable[], store: Store, baser: Uri
             if (doc.uri.scheme === 'sarif') {
                 return doc.uri.toString();
             }
-            return await baser.translateLocalToArtifact(doc.uri.toString());
+            return baser.translateLocalToArtifact(doc.uri);
         })();
         const severities = {
             error: DiagnosticSeverity.Error,

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -52,7 +52,7 @@ export async function activate(context: ExtensionContext) {
     activateSarifStatusBarItem(disposables);
     activateDiagnostics(disposables, store, baser, outputChannel);
     activateWatchDocuments(disposables, store, panel);
-    activateDecorations(disposables, store);
+    activateDecorations(disposables, store, baser);
     activateVirtualDocuments(disposables, store);
     activateSelectionSync(disposables, store, panel);
     activateGithubAnalyses(disposables, store, panel, outputChannel);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -133,6 +133,8 @@ function activateDiagnostics(disposables: Disposable[], store: Store, baser: Uri
         if (doc.fileName.endsWith('.git')) return;
         if (doc.uri.scheme === 'output') return; // Example "output:extension-output-MS-SarifVSCode.sarif-viewer-%231-Sarif%20Viewer"
         if (doc.uri.scheme === 'vscode') return; // Example "vscode:scm/git/scm0/input?rootUri..."
+        if (doc.uri.scheme === 'comment') return; // Represents a comment thread (from the VS Code Comments API)
+        if (doc.uri.scheme === 'vscode-terminal') return; // Represents a terminal (either integrated or from the VS Code Terminal API)
 
         const artifactUri = await (async () => {
             if (doc.uri.scheme === 'sarif') {

--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -140,9 +140,9 @@ export class Panel {
                     const log = store.logs.find(log => log._uri === logUri);
                     if (!log) return;
 
-                    const logUriUpgraded = log._uriUpgraded ?? log._uri;
+                    const logUriUpgraded = Uri.parse(log._uriUpgraded ?? log._uri, true);
                     if (!log._jsonMap) {
-                        const file = fs.readFileSync(Uri.parse(logUriUpgraded).fsPath, 'utf8')  // Assume scheme file.
+                        const file = fs.readFileSync(logUriUpgraded.fsPath, 'utf8')  // Assume scheme file.
                             .replace(/^\uFEFF/, ''); // Trim BOM.
                         log._jsonMap = (jsonMap.parse(file) as { pointers: JsonMap }).pointers;
                     }
@@ -178,7 +178,7 @@ export class Panel {
         }, undefined, context.subscriptions);
     }
 
-    public async selectLocal(logUri: string, localUri: string, region: Region | undefined) {
+    public async selectLocal(logUri: string, localUri: Uri, region: Region | undefined) {
         // Keep/pin active Log as needed
         for (const editor of window.visibleTextEditors.slice()) {
             if (editor.document.uri.toString() !== logUri) continue;
@@ -186,7 +186,7 @@ export class Panel {
             await commands.executeCommand('workbench.action.keepEditor');
         }
 
-        const currentDoc = await workspace.openTextDocument(Uri.parse(localUri, true));
+        const currentDoc = await workspace.openTextDocument(localUri);
 
         // `disableSelectionSync` prevents a selection sync feedback loop in cases where:
         // 1) `showTextDocument` creates a new editor (where no editor was already open).

--- a/src/extension/panel.ts
+++ b/src/extension/panel.ts
@@ -123,14 +123,14 @@ export class Panel {
                     break;
                 }
                 case 'select': {
-                    const {logUri, uri, region} = message as { logUri: string, uri: string, region: Region};
-                    const [_, runIndex, resultIndex] = message.id as ResultId;
+                    const {logUri, uri, uriBase, region} = message as { logUri: string, uri: string, uriBase: string | undefined, region: Region};
+                    const [_, runIndex] = message.id as ResultId;
 
                     const log = store.logs.find(log => log._uri === logUri);
                     if (!log) return;
 
                     const versionControlProvenance = log.runs[runIndex].versionControlProvenance;
-                    const validatedUri = await basing.translateArtifactToLocal(uri, versionControlProvenance);
+                    const validatedUri = await basing.translateArtifactToLocal(uri, uriBase, versionControlProvenance);
                     if (!validatedUri) return;
                     await this.selectLocal(logUri, validatedUri, region);
                     break;

--- a/src/extension/platformUriNormalize.ts
+++ b/src/extension/platformUriNormalize.ts
@@ -4,9 +4,9 @@
 import { Uri } from 'vscode';
 import platform from './platform';
 
-export default function(uri: string): string {
-    if (platform === 'win32' && Uri.parse(uri).scheme === 'file') {
-        return uri.toLowerCase();
+export default function(uri: Uri): Uri {
+    if (platform === 'win32' && uri.scheme === 'file') {
+        return Uri.parse(uri.toString().toLowerCase(), true);
     }
     return uri;
 }

--- a/src/extension/uriExists.ts
+++ b/src/extension/uriExists.ts
@@ -5,9 +5,9 @@ import { Uri, workspace } from 'vscode';
 
 // Hacky: We are using `fs.stat` to test the existence of documents as VS Code does not provide a dedicated existence API.
 // The similar Node `fs` API does not resolve custom URI schemes in the same way that VS Code does otherwise we would use that.
-export default async function uriExists(absoluteUri: string) {
+export default async function uriExists(absoluteUri: Uri) {
     try {
-        await workspace.fs.stat(Uri.parse(absoluteUri, true));
+        await workspace.fs.stat(absoluteUri);
     } catch (error) {
         return false;
     }

--- a/src/extension/uriRebaser.spec.ts
+++ b/src/extension/uriRebaser.spec.ts
@@ -15,14 +15,6 @@ describe('baser', () => {
         './platform': 'darwin',
     });
 
-    it('Array.commonLength', () => {
-        const commonLength = Array.commonLength(
-            ['a', 'b', 'c'],
-            ['a', 'b', 'd']
-        );
-        assert.strictEqual(commonLength, 2);
-    });
-
     it('translates uris - local -> artifact - case-insensitive file system', async () => {
         // Spaces inserted to emphasize common segments.
         const artifactUri = 'file://  /a/b'.replace(/ /g, '');

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -86,7 +86,7 @@ export class UriRebaser {
     // Notes:
     // If 2 logs have the same uri, then likely the same (unless the uri is super short)
     // If 2 logs don't have the same uri, they can still potentially be the same match
-    public async translateLocalToArtifact(localUri: Uri): Promise<string | undefined> { // Future: Ret undefined when certain.
+    public async translateLocalToArtifact(localUri: Uri): Promise<string | undefined> {
         // Need to refresh on uri map update.
         if (!this.validatedUrisLocalToArtifact.has(localUri)) {
             const { file } = platformUriNormalize(localUri).toString();

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -127,14 +127,7 @@ export class UriRebaser {
                 // If the end user has configured the SARIF consumer with a value for the uriBaseId...
                 // then the consumer SHALL use the configured value
                 for (const uriBase of this.uriBases) {
-                    let localUri: Uri;
-                    try {
-                        localUri = Uri.joinPath(Uri.parse(uriBase, true), artifactUri);
-                    } catch {
-                        // No URI scheme; assume the base is a file.
-                        localUri = Uri.file(path.join(uriBase, artifactUri));
-                    }
-
+                    const localUri = Uri.joinPath(Uri.parse(uriBase, true), artifactUri);
                     if (await uriExists(localUri)) {
                         this.updateValidatedUris(artifactUri, localUri);
                         return localUri;
@@ -144,14 +137,7 @@ export class UriRebaser {
                 // If uriBaseId is not yet resolved and theRun.originalUriBaseIds (§3.14.14) is present,
                 // the consumer SHALL attempt to resolve the uriBaseId from the information in originalUriBaseIds
                 if (uriBase) {
-                    let localUri: Uri;
-                    try {
-                        localUri = Uri.joinPath(Uri.parse(uriBase, true), artifactUri);
-                    } catch {
-                        // No URI scheme; assume the base is a file.
-                        localUri = Uri.file(path.join(uriBase, artifactUri));
-                    }
-
+                    const localUri = Uri.joinPath(Uri.parse(uriBase, true), artifactUri);
                     if (await uriExists(localUri)) {
                         this.updateValidatedUris(artifactUri, localUri);
                         return localUri;
@@ -171,16 +157,8 @@ export class UriRebaser {
                     }
                 }
             } else {
-                let localUri: Uri;
-                try {
-                    // file:///c:/whatever
-                    localUri = Uri.parse(artifactUri);
-                } catch {
-                    // c:/whatever
-                    localUri = Uri.file(artifactUri);
-                }
-
                 // File System Exist
+                const localUri = Uri.parse(artifactUri);
                 if (await uriExists(localUri)) {
                     this.updateValidatedUris(artifactUri, localUri);
                     return localUri;

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -244,7 +244,7 @@ export class UriRebaser {
                     if (choice === 'Yes' || choice === alwaysMsg) {
                         const mkdirRecursive = async (dir: string) => {
                             return new Promise((resolve, reject) => {
-                                fs.mkdir(dir, { recursive: true }, (error: any) => {
+                                fs.mkdir(dir, { recursive: true }, (error) => {
                                     if (error) {
                                         reject(error);
                                     } else {

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -72,10 +72,12 @@ export class UriRebaser {
     }
 
     private validatedUrisArtifactToLocal = new Map<string, Uri>()
-    private validatedUrisLocalToArtifact = new Map<Uri, string>()
+    private validatedUrisLocalToArtifact = new Map<string, string>()
     private updateValidatedUris(artifact: string, local: Uri) {
         this.validatedUrisArtifactToLocal.set(artifact, local);
-        this.validatedUrisLocalToArtifact.set(local, artifact);
+
+        // Maps use reference equality so we can't use Uri objects as keys.
+        this.validatedUrisLocalToArtifact.set(local.toString(), artifact);
     }
 
     // Other possibilities:
@@ -88,7 +90,7 @@ export class UriRebaser {
     // If 2 logs don't have the same uri, they can still potentially be the same match
     public async translateLocalToArtifact(localUri: Uri): Promise<string | undefined> {
         // Need to refresh on uri map update.
-        if (!this.validatedUrisLocalToArtifact.has(localUri)) {
+        if (!this.validatedUrisLocalToArtifact.has(localUri.toString())) {
             const { file } = platformUriNormalize(localUri).toString();
 
             // If no workspace then we choose to over-assume the localUri in-question is unique. It usually is,
@@ -103,7 +105,7 @@ export class UriRebaser {
                 this.updateBases(artifactUri, localUri);
             }
         }
-        return this.validatedUrisLocalToArtifact.get(localUri);
+        return this.validatedUrisLocalToArtifact.get(localUri.toString());
     }
 
     private extensionName = 'sarif-viewer'

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -133,8 +133,10 @@ export class UriRebaser {
                             localUri = Uri.file(path.join(uriBase, artifactUri)).toString();
                         }
 
-                        if (await uriExists(localUri))
+                        if (await uriExists(localUri)) {
+                            this.updateValidatedUris(artifactUri, localUri);
                             return localUri;
+                        }
                     }
                 }
 

--- a/src/extension/uriRebaser.ts
+++ b/src/extension/uriRebaser.ts
@@ -159,10 +159,19 @@ export class UriRebaser {
                     }
                 }
             } else {
+                let localUri: string;
+                try {
+                    // file:///c:/whatever
+                    localUri = Uri.parse(artifactUri).toString();
+                } catch {
+                    // c:/whatever
+                    localUri = Uri.file(artifactUri).toString();
+                }
+
                 // File System Exist
-                if (!isRelative && await uriExists(artifactUri)) {
-                    this.updateValidatedUris(artifactUri, artifactUri);
-                    return artifactUri;
+                if (await uriExists(localUri)) {
+                    this.updateValidatedUris(artifactUri, localUri);
+                    return localUri;
                 }
             }
 

--- a/src/panel/details.tsx
+++ b/src/panel/details.tsx
@@ -78,7 +78,7 @@ interface DetailsProps { result: Result, resultsFixed: string[], height: IObserv
                             <span>Locations</span>			<span className="svDetailsGridLocations">
                                                                 {result.locations?.map((loc, i) => {
                                                                     const ploc = loc.physicalLocation;
-                                                                    const [uri, _] = parseArtifactLocation(result, ploc?.artifactLocation);
+                                                                    const [uri] = parseArtifactLocation(result, ploc?.artifactLocation);
                                                                     return <a key={i} href="#" className="ellipsis" title={uri}
                                                                         onClick={e => {
                                                                             e.preventDefault(); // Cancel # nav.

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -56,7 +56,7 @@ export class IndexStore {
             const selectedRow = this.selection.get();
             const result = selectedRow instanceof RowItem && selectedRow.item;
             if (!result?._uri) return; // Bail on no result or location-less result.
-            postSelectArtifact(result, result.locations?.[0]?.physicalLocation, workspaceUri);
+            postSelectArtifact(result, result.locations?.[0]?.physicalLocation);
         });
     }
 
@@ -149,7 +149,7 @@ export async function postLoad() {
     await vscode.postMessage({ command: 'load' });
 }
 
-export async function postSelectArtifact(result: Result, ploc?: PhysicalLocation, overrideUriBase?: string) {
+export async function postSelectArtifact(result: Result, ploc?: PhysicalLocation) {
     // If this panel is not active, then any selection change did not originate from (a user's action) here.
     // It must have originated from (a user's action in) the editor, which then sent a message here.
     // If that is the case, don't send another 'select' message back. This would cause selection unstability.
@@ -160,7 +160,7 @@ export async function postSelectArtifact(result: Result, ploc?: PhysicalLocation
     if (!ploc) return;
     const log = result._log;
     const logUri = log._uri;
-    const [uri, uriBase, uriContent] = parseArtifactLocation(result, ploc?.artifactLocation, overrideUriBase);
+    const [uri, uriBase, uriContent] = parseArtifactLocation(result, ploc?.artifactLocation);
     const region = ploc?.region;
     await vscode.postMessage({ command: 'select', logUri, uri: uriContent ?? uri, uriBase, region, id: result._id });
 }

--- a/src/panel/indexStore.ts
+++ b/src/panel/indexStore.ts
@@ -160,9 +160,9 @@ export async function postSelectArtifact(result: Result, ploc?: PhysicalLocation
     if (!ploc) return;
     const log = result._log;
     const logUri = log._uri;
-    const [uri, uriContent] = parseArtifactLocation(result, ploc?.artifactLocation, overrideUriBase);
+    const [uri, uriBase, uriContent] = parseArtifactLocation(result, ploc?.artifactLocation, overrideUriBase);
     const region = ploc?.region;
-    await vscode.postMessage({ command: 'select', logUri, uri: uriContent ?? uri, region, id: result._id });
+    await vscode.postMessage({ command: 'select', logUri, uri: uriContent ?? uri, uriBase, region, id: result._id });
 }
 
 export async function postSelectLog(result: Result) {

--- a/src/shared/extension.spec.ts
+++ b/src/shared/extension.spec.ts
@@ -5,21 +5,6 @@
 import assert from 'assert';
 
 describe('Extension', () => {
-    describe('Array.commonLength', () => {
-        it('finds the length of common consecutive elements when common elements start from index 0', () => {
-            assert.strictEqual(Array.commonLength(['a', 'b', 'c'], ['a', 'b', 'd', 'e']), 2);
-        });
-        it('returns zero if common consecutive elements do not start from 0 index', () => {
-            assert.strictEqual(Array.commonLength(['a', 'b', 'c'], ['b', 'c', 'd']), 0);
-        });
-        it('returns zero if no common consecutive elements', () => {
-            assert.strictEqual(Array.commonLength(['a', 'b', 'c'], ['x', 'y', 'z']), 0);
-        });
-        it('returns zero if one array is empty', () => {
-            assert.strictEqual(Array.commonLength(['a', 'b', 'c'], []), 0);
-            assert.strictEqual(Array.commonLength([], ['a', 'b']), 0);
-        });
-    });
     describe('Array.prototype.last', () => {
         it('finds the last element when more than 1 elements are present', () => {
             assert.strictEqual(['a', 'b', 'c'].last, 'c');

--- a/src/shared/extension.ts
+++ b/src/shared/extension.ts
@@ -11,9 +11,6 @@ export {};
 type Selector<T> = (_: T) => number | string
 
 declare global {
-    interface ArrayConstructor {
-        commonLength(a: any[], b: any[]): number;
-    }
     interface Array<T> {
         last: T;
         replace(items: T[]): void; // From Mobx, but not showing up.
@@ -26,16 +23,6 @@ declare global {
         path: string;
     }
 }
-
-!Array.hasOwnProperty('commonLength') &&
-Object.defineProperty(Array, 'commonLength', {
-    value: function(a: any[], b: any[]): number {
-        let i = 0;
-        // eslint-disable-next-line no-empty
-        for (; a[i] === b[i] && i < a.length && i < b.length; i++) {}
-        return i;
-    }
-});
 
 !Array.prototype.hasOwnProperty('last') &&
 Object.defineProperty(Array.prototype, 'last', {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { ArtifactLocation, Location, Log, ReportingDescriptor, Result } from 'sarif';
-import urlJoin from 'url-join';
 import { URI } from 'vscode-uri';
 
 type JsonLocation = { line: number, column: number } // Unused: pos
@@ -98,7 +97,7 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>, w
             result._id = [log._uri, runIndex, resultIndex];
 
             const ploc = result.locations?.[0]?.physicalLocation;
-            const [uri, _, uriContents] = parseArtifactLocation(result, ploc?.artifactLocation, workspaceUri);
+            const [uri, _, uriContents] = parseArtifactLocation(result, ploc?.artifactLocation);
             result._uri = uri;
             result._uriContents = uriContents;
             result._relativeUri = result._uri?.replace(workspaceUri ?? '' , '') ?? ''; // For grouping, Empty works more predictably than undefined
@@ -170,15 +169,15 @@ Run.artifacts: Art[]
    location: ArtLoc
    contents: ArtCon
 */
-export function parseLocation(result: Result, loc?: Location, overrideUriBase?: string) {
+export function parseLocation(result: Result, loc?: Location) {
     const message = loc?.message?.text;
-    const [uri, _, uriContent] = parseArtifactLocation(result, loc?.physicalLocation?.artifactLocation, overrideUriBase);
+    const [uri, _, uriContent] = parseArtifactLocation(result, loc?.physicalLocation?.artifactLocation);
     const region = loc?.physicalLocation?.region;
     return { message, uri, uriContent, region };
 }
 
 // Improve: `result` purely used for `_run.artifacts`.
-export function parseArtifactLocation(result: Pick<Result, '_log' | '_run'>, anyArtLoc: ArtifactLocation | undefined, overrideUriBase?: string) {
+export function parseArtifactLocation(result: Pick<Result, '_log' | '_run'>, anyArtLoc: ArtifactLocation | undefined) {
     if (!anyArtLoc) return [undefined, undefined, undefined];
     const runArt = result._run.artifacts?.[anyArtLoc.index ?? -1];
     const runArtLoc = runArt?.location;

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -98,7 +98,7 @@ export function augmentLog(log: Log, rules?: Map<string, ReportingDescriptor>, w
             result._id = [log._uri, runIndex, resultIndex];
 
             const ploc = result.locations?.[0]?.physicalLocation;
-            const [uri, uriContents] = parseArtifactLocation(result, ploc?.artifactLocation, workspaceUri);
+            const [uri, _, uriContents] = parseArtifactLocation(result, ploc?.artifactLocation, workspaceUri);
             result._uri = uri;
             result._uriContents = uriContents;
             result._relativeUri = result._uri?.replace(workspaceUri ?? '' , '') ?? ''; // For grouping, Empty works more predictably than undefined
@@ -172,14 +172,14 @@ Run.artifacts: Art[]
 */
 export function parseLocation(result: Result, loc?: Location, overrideUriBase?: string) {
     const message = loc?.message?.text;
-    const [uri, uriContent] = parseArtifactLocation(result, loc?.physicalLocation?.artifactLocation, overrideUriBase);
+    const [uri, _, uriContent] = parseArtifactLocation(result, loc?.physicalLocation?.artifactLocation, overrideUriBase);
     const region = loc?.physicalLocation?.region;
     return { message, uri, uriContent, region };
 }
 
 // Improve: `result` purely used for `_run.artifacts`.
 export function parseArtifactLocation(result: Pick<Result, '_log' | '_run'>, anyArtLoc: ArtifactLocation | undefined, overrideUriBase?: string) {
-    if (!anyArtLoc) return [undefined, undefined];
+    if (!anyArtLoc) return [undefined, undefined, undefined];
     const runArt = result._run.artifacts?.[anyArtLoc.index ?? -1];
     const runArtLoc = runArt?.location;
     const runArtCon = runArt?.contents;
@@ -188,22 +188,8 @@ export function parseArtifactLocation(result: Pick<Result, '_log' | '_run'>, any
     // Currently not supported: recursive resolution of uriBaseId.
     // Note: While an uriBase often results in an absolute URI, there is no guarantee.
     // Note: While an uriBase often represents the project root, there is no guarantee.
-    // const uriBaseId = anyArtLoc.uriBaseId ?? runArtLoc?.uriBaseId;
-    // if (uriBaseId) {
-    //     const uriBase
-    //         =  overrideUriBase // Typically the workspaceUri, which takes precedence.
-    //         ?? result._run.originalUriBaseIds?.[uriBaseId]?.uri
-    //         ?? '';
-    //     uri = urlJoin(uriBase, uri);
-    // }
-
-    // // Determine if `uri` absolute or relative. Using scheme as an approximation.
-    // const rxUriScheme = /^([^:/?#]+?):/;
-    // const isRelative = !rxUriScheme.test(uri);
-    // if (isRelative) {
-    //     uri = urlJoin(overrideUriBase ?? 'file://', uri);
-    //     // After this point, the URI must be absolute.
-    // }
+    const uriBaseId = anyArtLoc.uriBaseId ?? runArtLoc?.uriBaseId;
+    const uriBase = uriBaseId ? result._run.originalUriBaseIds?.[uriBaseId]?.uri : undefined;
 
     // A shorter more transparent URI format would be:
     // `sarif://${encodeURIComponent(result._log._uri)}/${result._run._index}/${anyArtLoc.index}/${uri?.file ?? 'Untitled'}`
@@ -212,7 +198,7 @@ export function parseArtifactLocation(result: Pick<Result, '_log' | '_run'>, any
     const uriContents = runArtCon?.text || runArtCon?.binary
         ? encodeURI(`sarif:${encodeURIComponent(result._log._uri)}/${result._run._index}/${anyArtLoc.index}/${uri?.file ?? 'Untitled'}`)
         : undefined;
-    return [uri, uriContents];
+    return [uri, uriBase, uriContents];
 }
 
 export function decodeFileUri(uriString: string) {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -183,27 +183,27 @@ export function parseArtifactLocation(result: Pick<Result, '_log' | '_run'>, any
     const runArt = result._run.artifacts?.[anyArtLoc.index ?? -1];
     const runArtLoc = runArt?.location;
     const runArtCon = runArt?.contents;
-    let uri = anyArtLoc.uri ?? runArtLoc?.uri ?? ''; // If index (§3.4.5) is absent, uri SHALL be present.
+    const uri = anyArtLoc.uri ?? runArtLoc?.uri ?? ''; // If index (§3.4.5) is absent, uri SHALL be present.
 
     // Currently not supported: recursive resolution of uriBaseId.
     // Note: While an uriBase often results in an absolute URI, there is no guarantee.
     // Note: While an uriBase often represents the project root, there is no guarantee.
-    const uriBaseId = anyArtLoc.uriBaseId ?? runArtLoc?.uriBaseId;
-    if (uriBaseId) {
-        const uriBase
-            =  overrideUriBase // Typically the workspaceUri, which takes precedence.
-            ?? result._run.originalUriBaseIds?.[uriBaseId]?.uri
-            ?? '';
-        uri = urlJoin(uriBase, uri);
-    }
+    // const uriBaseId = anyArtLoc.uriBaseId ?? runArtLoc?.uriBaseId;
+    // if (uriBaseId) {
+    //     const uriBase
+    //         =  overrideUriBase // Typically the workspaceUri, which takes precedence.
+    //         ?? result._run.originalUriBaseIds?.[uriBaseId]?.uri
+    //         ?? '';
+    //     uri = urlJoin(uriBase, uri);
+    // }
 
-    // Determine if `uri` absolute or relative. Using scheme as an approximation.
-    const rxUriScheme = /^([^:/?#]+?):/;
-    const isRelative = !rxUriScheme.test(uri);
-    if (isRelative) {
-        uri = urlJoin(overrideUriBase ?? 'file://', uri);
-        // After this point, the URI must be absolute.
-    }
+    // // Determine if `uri` absolute or relative. Using scheme as an approximation.
+    // const rxUriScheme = /^([^:/?#]+?):/;
+    // const isRelative = !rxUriScheme.test(uri);
+    // if (isRelative) {
+    //     uri = urlJoin(overrideUriBase ?? 'file://', uri);
+    //     // After this point, the URI must be absolute.
+    // }
 
     // A shorter more transparent URI format would be:
     // `sarif://${encodeURIComponent(result._log._uri)}/${result._run._index}/${anyArtLoc.index}/${uri?.file ?? 'Untitled'}`


### PR DESCRIPTION
Fixes #506

This is a bigger change than I thought it would be, so I would really appreciate some eyes and feedback on it to ensure:
1. This is spec-compliant
2. I'm not breaking existing behavior

The crux of the change is removing all URI parsing logic from `parseArtifactLocation` and instead updating `UriRebaser.translateArtifactToLocal` to handle raw SARIF artifact paths.

Since translateArtifactToLocal now acts on the verbatim artifact URIs, that allows us to easily prepend extension-provided uriBases. However, as a side effect, `artifactUri` is no longer guaranteed to be an actual URI, so lots of the other changes were updating supporting codepaths (e.g. all the base translation) to handle simple filesystem paths, not just URIs.

Validation:
* Relative path and an extension-provided uriBase ✅
* Relative path and a uriBase defined within the SARIF file ✅
* Absolute path that exists on disk ✅
* Relative path that has a distinct project item match ✅
* Relative path that needs location lookup ✅
* Relative path with workspace concatenation ✅
* Relative path that has an open doc match ✅
* Absolute path that doesn't exist on disk but does have a distinct project item match ✅

Sidenotes.
* Since we're operating on FS paths, seems like we should be using `Uri.fsPath` instead of `Uri.path` everywhere, but that's even more potential to breakage so I didn't touch that. Something to keep in mind though.
* It would be nice if `artifactUri` could be renamed to something that didn't imply it was `Uri`, because it isn't (whereas `localUri` _is_ a `Uri`)
* I couldn't run the test suite because it's failing to initialize due to a myriad of pre-existing TypeScript errors.