### PR TITLE
Support `uriBaseId` for artifact locations in fixes.

### DIFF
--- a/src/extension/index.activateFixes.ts
+++ b/src/extension/index.activateFixes.ts
@@ -46,7 +46,8 @@ export function activateFixes(disposables: Disposable[], store: Pick<Store, 'ana
                 if (fix) {
                     const edit = new WorkspaceEdit();
                     for (const artifactChange of fix.artifactChanges) {
-                        const [uri, _uriContents] = parseArtifactLocation(result, artifactChange.artifactLocation);
+                        const workspaceUri = workspace.workspaceFolders?.[0]?.uri.toString(); // TODO: Handle multiple workspaces.
+                        const [uri, _uriContents] = parseArtifactLocation(result, artifactChange.artifactLocation, workspaceUri);
                         const artifactUri = uri;
                         if (!artifactUri) continue;
 


### PR DESCRIPTION
They are supported for other artifact locations (e.g., [here](https://github.com/microsoft/sarif-vscode-extension/blob/d161181d4f04e41d3b5eeaa36b2971b7ff6d2af6/src/extension/index.activateDecorations.ts#L77)), so I think it makes sense to treat fixes the same.