### PR TITLE
Fix compile errors and warnings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,9 +16,8 @@
             "name": "Launch Mocha",
             "type": "node",
             "request": "launch",
-            "program": "${workspaceRoot}/node_modules/mocha/bin/mocha",          
-            "args": ["--color", "--inspect-brk=9229"], // "${file}"
-            "port": 9229,
+            "program": "${workspaceRoot}/node_modules/.bin/mocha",
+            "args": ["--color", "--inspect-brk=9229", "${file}"], //
             "skipFiles": [
                 "<node_internals>/**/*.js",
                 "${workspaceFolder}/node_modules/**/*.js",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "type": "node",
             "request": "launch",
             "program": "${workspaceRoot}/node_modules/.bin/mocha",
-            "args": ["--color", "--inspect-brk=9229", "${file}"], //
+            "args": ["--color", "--inspect-brk=9229", "${file}"],
             "skipFiles": [
                 "<node_internals>/**/*.js",
                 "${workspaceFolder}/node_modules/**/*.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sarif-viewer",
-    "version": "3.3.5",
+    "version": "3.3.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sarif-viewer",
-            "version": "3.3.5",
+            "version": "3.3.7",
             "license": "MIT",
             "dependencies": {
                 "@types/diff": "^5.0.2",
@@ -43,7 +43,7 @@
                 "@types/sinon": "9.0.4",
                 "@types/tmp": "0.1.0",
                 "@types/url-join": "4.0.0",
-                "@types/vscode": "1.57",
+                "@types/vscode": "1.79.1",
                 "@typescript-eslint/eslint-plugin": "3.1.0",
                 "@typescript-eslint/parser": "3.1.0",
                 "@zeit/ncc": "0.22.1",
@@ -1051,9 +1051,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.57.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.1.tgz",
-            "integrity": "sha512-I+NlKdnDnUZZ5HYu3F99ye3ERORnoqdyPer6nXVC7ToU/4WEjrCQOlLosmLyVoi75+UbKCJMFqTgeZuID+8yoA==",
+            "version": "1.79.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.1.tgz",
+            "integrity": "sha512-Ikwc4YbHABzqthrWfeAvItaAIfX9mdjMWxqNgTpGjhgOu0TMRq9LzyZ2yBK0JhYqoSjEubEPawf6zJgnl6Egtw==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -12701,9 +12701,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.57.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.1.tgz",
-            "integrity": "sha512-I+NlKdnDnUZZ5HYu3F99ye3ERORnoqdyPer6nXVC7ToU/4WEjrCQOlLosmLyVoi75+UbKCJMFqTgeZuID+8yoA==",
+            "version": "1.79.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.1.tgz",
+            "integrity": "sha512-Ikwc4YbHABzqthrWfeAvItaAIfX9mdjMWxqNgTpGjhgOu0TMRq9LzyZ2yBK0JhYqoSjEubEPawf6zJgnl6Egtw==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     },
     "activationEvents": [
         "onLanguage:json",
-        "onCommand:sarif.showPanel",
-        "onCommand:sarif.clearState",
         "workspaceContains:.git",
         "workspaceContains:.sarif"
     ],
@@ -162,7 +160,7 @@
         "@types/sinon": "9.0.4",
         "@types/tmp": "0.1.0",
         "@types/url-join": "4.0.0",
-        "@types/vscode": "1.57",
+        "@types/vscode": "1.79.1",
         "@typescript-eslint/eslint-plugin": "3.1.0",
         "@typescript-eslint/parser": "3.1.0",
         "@zeit/ncc": "0.22.1",

--- a/src/extension/index.activateDecorations.ts
+++ b/src/extension/index.activateDecorations.ts
@@ -31,13 +31,13 @@ export function activateDecorations(disposables: Disposable[], store: Store) {
     // On selection change, set the `activeResultId`.
     disposables.push(languages.registerCodeActionsProvider('*', {
         provideCodeActions: (_doc, _range, context) => {
-            if (context.only) return;
+            if (context.only) return undefined;
 
             const diagnostic = context.diagnostics[0] as ResultDiagnostic | undefined;
-            if (!diagnostic) return;
+            if (!diagnostic) return undefined;
 
             const result = diagnostic?.result;
-            if (!result) return; // Don't clear the decorations. See `activeResultId` comments.
+            if (!result) return undefined; // Don't clear the decorations. See `activeResultId` comments.
 
             activeResultId.set(JSON.stringify(result._id)); // Stringify for comparability.
 

--- a/src/extension/index.activateFixes.ts
+++ b/src/extension/index.activateFixes.ts
@@ -23,10 +23,10 @@ export function activateFixes(disposables: Disposable[], store: Pick<Store, 'ana
                 // { value: 'quickFix' } │ Invoke=1             │ Before hover tooltip is shown. Return only specific code actions.
 
                 const diagnostic = context.diagnostics[0] as ResultDiagnostic | undefined;
-                if (!diagnostic) return;
+                if (!diagnostic) return undefined;
 
                 const result = diagnostic?.result;
-                if (!result) return;
+                if (!result) return undefined;
 
                 return [
                     new ResultQuickFix(diagnostic, result), // Mark as fixed
@@ -41,7 +41,7 @@ export function activateFixes(disposables: Disposable[], store: Pick<Store, 'ana
             async resolveCodeAction(codeAction: ResultQuickFix) {
                 const { result, fix, command } = codeAction;
 
-                if (command) return; // VS Code will execute the command on our behalf.
+                if (command) return undefined; // VS Code will execute the command on our behalf.
 
                 if (fix) {
                     const edit = new WorkspaceEdit();

--- a/src/panel/global.d.ts
+++ b/src/panel/global.d.ts
@@ -14,8 +14,14 @@ declare global {
         indexOf(searchElement: T | undefined, fromIndex?: number | undefined): number;
     }
 
-    const acquireVsCodeApi: any; // VS Code does not provide type info.
-    const vscode: any; // VS Code does not provide type info.
+    interface VsCodeApi {
+        /**
+         * Post message back to vscode extension.
+         */
+        postMessage(msg: any): void;
+    }
+
+    const vscode: VsCodeApi;
 
     namespace NodeJS {
         interface Global {

--- a/src/panel/resultTableStore.spec.ts
+++ b/src/panel/resultTableStore.spec.ts
@@ -10,7 +10,10 @@ import assert from 'assert';
 import { Result } from 'sarif';
 
 describe('ResultTableStore', () => {
-    const resultsSource = { results: log.runs![0].results! };
+    const resultsSource = {
+        results: log.runs![0].results!,
+        resultsFixed: []
+    };
     const selection = observable.box<Row | undefined>(undefined);
     const filtersSource = {
         keywords: '',

--- a/src/panel/widgets.tsx
+++ b/src/panel/widgets.tsx
@@ -261,7 +261,7 @@ export function renderMessageTextWithEmbeddedLinks(text: string, result: Result,
                 .split(/(\[[^\]]*\]\([^)]+\))/g)
                 .map((item, i) => {
                     if (i % 2 === 0) return item;
-                    const [_, text, id] = item.match(rxLink)!; // Safe since it was split by the same RegExp.
+                    const [, text, id] = item.match(rxLink)!; // Safe since it was split by the same RegExp.
                     return isNaN(+id)
                         ? <a key={i} tabIndex={-1} href={id}>{text}</a>
                         : <a key={i} tabIndex={-1} href="#" onClick={e => {
@@ -272,4 +272,5 @@ export function renderMessageTextWithEmbeddedLinks(text: string, result: Result,
                 })
             : text;
     }
+    return undefined;
 }


### PR DESCRIPTION
Here are a few behaviour preserving changes that I made that helps avoid some compiler errors and warnings.

- Updated launch config for mocha (tests are failing, but at least it launches)
- Updated versions in package-lock.json
- Updated `@types/vscode` to latest
- Removed two `onCommand` triggers that are now deprecated
- Added `const vscode: VsCodeApi` to `global.d.ts` to get properly typed references to `vscode` instance in the webview.
- Converted `return` to `return undefined` where appropriate to make compiler happy.
- Also, a handful of other errors that the compiler was complaining about.