### PR TITLE
Avoid crashing if a git repo has no `origin`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,6 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-            "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/**/*.js" ],
             "preLaunchTask": "npm: start"


### PR DESCRIPTION
If there is no `origin`, then choose the first remote in the config. If there are no remotes, exit early and send telemetry.

Fixes https://github.com/microsoft/sarif-vscode-extension/issues/515