### PR TITLE
Fix AdvSec URL extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "sarif-viewer",
-    "displayName": "Sarif Viewer",
+    "displayName": "SARIF Viewer",
     "description": "Adds support for viewing SARIF logs",
     "author": "Microsoft Corporation",
     "license": "MIT",
-    "version": "3.3.9",
+    "version": "3.4.0",
     "publisher": "MS-SarifVSCode",
     "repository": {
         "type": "git",
@@ -34,7 +34,7 @@
     "main": "./out/context.js",
     "contributes": {
         "configuration": {
-            "title": "Sarif Viewer",
+            "title": "SARIF Viewer",
             "properties": {
                 "sarif-viewer.rootpaths": {
                     "type": "array",

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -58,20 +58,14 @@ export async function activate(context: ExtensionContext) {
         async handleUri(uri: vscode.Uri) {
             if (uri.path.toLowerCase() === '/alert') {
                 // Launched by Azure DevOps Advanced Security alert page.
-                const params = new URLSearchParams(uri.query);
+                const param = uri.query.split('url=');
 
-                // Find the url parameter.
-                for (const param of params) {
-                    if (param[0] === 'url') {
-                        // Decode the alert API URL and pass it to the load function.
-                        const url = decodeURIComponent(param[1]);
-                        if (url.startsWith('https://advsec.dev.azure.com/')) {
-                            await loadAlertSarif(new URL(url));
-                        } else {
-                            void window.showWarningMessage(`Invalid callback URL '${url}'. URL must point to 'https://advsec.dev.azure.com/'.`, 'OK');
-                        }
-                        break;
-                    }
+                // Decode the alert API URL and pass it to the load function.
+                const url = decodeURIComponent(param[1]);
+                if (url.startsWith('https://advsec.dev.azure.com/')) {
+                    await loadAlertSarif(new URL(url));
+                } else {
+                    void window.showWarningMessage(`Invalid callback URL '${url}'. URL must point to 'https://advsec.dev.azure.com/'.`, 'OK');
                 }
             }
         }


### PR DESCRIPTION
decodeURIComponent doesn't handle the url param correctly. It drops all but the first param because it thinks the ampersands are part of the parent query string. So this change just splits on the param name we expect and uses the whole value as the AdvSec target API.