### PR TITLE
Convert to linux runner for creating releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   createPrerelease:
     name: Create Release
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1


### PR DESCRIPTION
This will make it faster to run this workflow. As it is, getting a macos runner can take a while.