### PR TITLE
Give GITHUB_TOKEN release permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ jobs:
   createPrerelease:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      # Release creation
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1


### PR DESCRIPTION
GITHUB_TOKEN was changed to default to read-only earlier this year: https://docs.opensource.microsoft.com/github/apps/permission-changes/

The right permission to add back is write access to [`contents`](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents) (which covers...a scary amount of things).