### PR TITLE
Expose SARIF ruleId as diagnostic code in Problems view

### DIFF
--- a/src/extension/resultDiagnostic.ts
+++ b/src/extension/resultDiagnostic.ts
@@ -7,5 +7,8 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode';
 export class ResultDiagnostic extends Diagnostic {
     constructor(range: Range, message: string, severity: DiagnosticSeverity, readonly result: Result) {
         super(range, message, severity);
+        // Expose SARIF(ruleId) in problem panel - code'.
+        this.code = result.ruleId
+        this.source = 'SARIF'
     }
 }


### PR DESCRIPTION
References #620 

Expose SARIF result `ruleId` as the VS Code diagnostic code so it appears in:

1. the Problems view (e.g. `SARIF(ruleId)`) in table mode - currently showing '-'
2. In the problem popup. Currently not showing source/code.

This is consistent with the way other extensions (e.g. TS, C/C++) present errors. No behavior change when `ruleId` is not present. 

Sample output before/after - using the current test case (`demos/distinctNameMatching/.sarif/log.sarif`) - labeling the issue as `SARIF(DEMO01)`

Before:
<img width="546" height="247" alt="image" src="https://github.com/user-attachments/assets/a75b383a-09d5-4353-afe6-dc2698a13591" />

After:
<img width="387" height="288" alt="image" src="https://github.com/user-attachments/assets/a825348e-3b84-4a28-acf3-7d63564a082e" />
